### PR TITLE
chore: change default for optimise function to trigger compaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infino-ai/code-context",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@infino-ai/code-context",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -10,7 +10,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { IndexSpec, type Connection } from "@infino-ai/infino";
+import { IndexSpec, type Connection, type OptimizeOptions } from "@infino-ai/infino";
 import { APPEND_BATCH, EMBED_BATCH, N_CENT, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
 import { walkRepo } from "./walker.js";
 import { shouldIndexFile, chunkFile, looksBinary, type Chunk } from "./chunker.js";
@@ -24,6 +24,9 @@ import {
   type FileState,
 } from "./filestate.js";
 import type { Embedder } from "./embedder.js";
+
+const COMPACTION_TARGET_MIB =
+  parseInt(process.env.CX_COMPACTION_TARGET_MIB ?? "", 10) || 10;
 
 export interface IndexOptions {
   root: string;
@@ -332,6 +335,9 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
   };
   writeManifest(indexDirPath, nextManifest);
 
+  // --- compact after deletes/appends to keep tombstones clean ---
+  compact(table);
+
   return {
     action: "synced",
     filesAdded: diff.added.length,
@@ -346,13 +352,16 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
   };
 }
 
-/** Post-build compaction: batched appends leave many small superfiles behind
+/** Post-build/sync compaction: batched appends leave many small superfiles behind
  * (measured 3-4x index-size bloat on large repos); merge them and sweep the
  * orphans. The 60s gc grace protects any reader mid-query in another
- * process. Best-effort - a failed compaction never fails the build. */
-function compact(table: { optimize(): void; gc(graceSecs: number): unknown }): void {
+ * process. Tuned for small-file workloads via CX_COMPACTION_TARGET_MIB env var
+ * (default 10 MiB, triggers compaction at ~8 MiB with 80% fill).
+ * Best-effort - a failed compaction never fails the operation. */
+function compact(table: { optimize(opts?: OptimizeOptions): void; gc(graceSecs: number): unknown }): void {
   try {
-    table.optimize();
+    const opts: OptimizeOptions = { targetSuperfileSizeMb: COMPACTION_TARGET_MIB };
+    table.optimize(opts);
     table.gc(60);
   } catch {
     /* e.g. non-durable storage - the index still works, just bigger */

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -156,4 +156,28 @@ describe("syncRepo", () => {
     const state = readFileState(dir)!;
     expect(Object.keys(state.files).sort()).toEqual(["src/alpha.ts", "src/gamma.ts"]);
   });
+
+  it("compacts after sync (tombstones cleaned up)", async () => {
+    // Perform multiple edit cycles to accumulate tombstones, verify compaction succeeds
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(root, "src", `delta-${i}.ts`), `export const v${i} = '${i}';\n`);
+    }
+    const outcome1 = await syncRepo(opts());
+    expect(outcome1.action).toBe("synced");
+
+    // Delete the added files to create tombstones
+    for (let i = 0; i < 3; i++) {
+      rmSync(join(root, "src", `delta-${i}.ts`));
+    }
+    const outcome2 = await syncRepo(opts());
+    expect(outcome2.action).toBe("synced");
+    if (outcome2.action !== "synced") return;
+    expect(outcome2.filesDeleted).toBe(3);
+
+    // Verify index still responds after compaction (no data corruption)
+    const rowCount = Number(
+      (db.querySql("SELECT COUNT(*) AS n FROM chunks") as Array<{ n: unknown }>)[0].n,
+    );
+    expect(rowCount).toBeGreaterThan(0); // original files remain
+  });
 });


### PR DESCRIPTION
### What is this change?

Optimise function runs compaction and gc, the current defaults are 1024mb of merged files, and trigger is 800mb. Given codebases are usually very small, the limits will never be hit most of the times and compact will never run, leading to slight increase in latency due to eventual tombstones and lot of small files. 

This PR reduces the trigger for compaction