### PR TITLE
Improve agent DX: multi-repo sessions, auto-index, partial-index honesty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,13 @@ the honest limits in [docs/tradeoffs.md](docs/tradeoffs.md).
 
 - `src/cli.ts`: the `cx` / `code-context` command entry (commander).
 - `src/mcp/server.ts`: the MCP server, three tools (`search`, `sql`,
-  `reindex`) over one index.
+  `reindex`). Each takes an optional `path` (repo root) so one server serves
+  multiple repos in a session, defaulting to the startup root.
+- `src/mcp/repos.ts`: the per-repo registry - resolves and validates a
+  requested root, one engine connection per repo, LRU-capped.
+- `src/mcp/ensure.ts`: auto-index on first query - a `search`/`sql` on a
+  never-indexed repo builds the index inline, then answers on the same call
+  (`CX_AUTO_INDEX=0` restores the strict "index it first" error).
 - `src/core/`: the engine-facing core. `chunker` (tree-sitter chunking),
   `indexer` (build + staged readiness + incremental sync), `searcher`
   (hybrid search + SQL), `embedder` (local model), `filestate` (incremental

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ Add it to Claude Code with one command, nothing to install:
 claude mcp add code-context -- npx -y @infino-ai/code-context mcp
 ```
 
-Then ask the agent to "index this codebase": the `reindex` tool bootstraps an
-unindexed repo in-chat, and search works while indexing runs.
+Then just ask a question about the code. The first `search` or `sql` on an
+unindexed repo builds the index inline and answers on the same call: keyword
+search is live in seconds, and vectors backfill in the background. (Prefer to
+kick it off yourself? The `reindex` tool does the same build on demand.)
 
 CI-tested on Linux x64 (glibc) and macOS arm64; linux-arm64, musl, and
 Windows-via-WSL are expected to work through the engine's prebuilt bindings
@@ -135,9 +137,9 @@ The default model optimizes quality-per-minute. See
 
 ### Your index is just files
 
-Everything lives in `.infino/` in your repo root (add it to your
-`.gitignore`): plain files you can copy, cache in CI, or put on object
-storage. It's a live index the engine queries in place, not a snapshot you
+Everything lives in `.infino/` in your repo root (added to your
+`.gitignore` automatically on first index): plain files you can copy,
+cache in CI, or put on object storage. It's a live index the engine queries in place, not a snapshot you
 export and pass around.
 
 ## Setup for agents
@@ -208,13 +210,20 @@ Tools: `search`, `sql`, `reindex` (incremental sync: an unchanged repo is
 a fast no-op, and the server also auto-syncs in the background as queries
 arrive, so results track your edits without anyone asking).
 
+**Multiple repos in one session.** Each tool takes an optional `path` (an
+absolute repo root). Omit it and the server uses its startup root; set it to
+target a specific repo when a session spans more than one. One server
+instance serves them all, each with its own index in its own `.infino/` -
+no restart, no per-repo config.
+
 ## Configuration
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `CX_INDEX_DIR` | `<repo>/.infino` | where the index lives |
-| `CX_MAX_FILES` / `CX_MAX_FILE_BYTES` | 20000 / 1MB | indexing caps |
-| `CX_ROOT` | current directory | repo root for the MCP server / CLI when not run from the repo |
+| `CX_MAX_FILES` / `CX_MAX_FILE_BYTES` | 20000 / 1MB | indexing caps (files over the file cap are left out; `search`/`sql` then flag the index as partial so an absence isn't read as proof) |
+| `CX_ROOT` | current directory | default repo root for the MCP server / CLI when not run from the repo (each tool call can override it with a `path` argument) |
+| `CX_AUTO_INDEX` | on | `0` makes a query on an unindexed repo error instead of building the index inline on the first `search`/`sql` |
 | `CX_AUTO_SYNC` | on | `0` disables the MCP server's background staleness sync |
 | `CX_SYNC_INTERVAL_SECS` | 30 | auto-sync debounce between staleness checks |
 | `CX_NO_EMBED` | off | keyword-only mode for the MCP server (skip the vector stage) |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,11 +30,27 @@ background and semantic and hybrid ranking unlock automatically when they
 land. If the vector stage fails, keyword search stays live and the index
 reports that honestly rather than failing.
 
+### Do I have to index before I can search?
+
+No. The first `search` or `sql` on a repo that has never been indexed builds
+the index inline and answers on that same call - keyword search is live in
+seconds, vectors backfill behind it. Call `reindex` first if you'd rather
+kick the build off explicitly, or set `CX_AUTO_INDEX=0` to make an unindexed
+query return a "index it first" error instead of building.
+
+### Can one server handle more than one repo?
+
+Yes. Each tool takes an optional `path` (an absolute repo root); omit it to
+use the server's startup root, or pass it to target a specific repo when a
+session spans several. One server instance serves them all, each with its own
+index in its own `.infino/`.
+
 ### Where does the index live, and can I share it?
 
-In `.infino/` in your repo root, as plain files (add it to your `.gitignore`).
-You can copy it, cache it in CI, or put it on object storage. It is a live
-index the engine queries in place, not a snapshot you export.
+In `.infino/` in your repo root, as plain files (added to your `.gitignore`
+automatically the first time you index). You can copy it, cache it in CI, or
+put it on object storage. It is a live index the engine queries in place, not
+a snapshot you export.
 
 ### Does it stay fresh as I edit?
 
@@ -42,6 +58,16 @@ Yes. Sync is incremental: a per-file state map (size/mtime prefilter, then
 content hash) re-chunks and re-embeds only the files that changed, so a
 one-file edit syncs in a fraction of a second and an unchanged tree is a fast
 no-op. The MCP server also auto-syncs in the background as queries arrive.
+
+### What happens on a repo too big to index fully?
+
+Indexing caps how many files it takes (`CX_MAX_FILES`, default 20,000); files
+past the cap are left out. When that happens the index is marked partial:
+every `search` and `sql` result carries a `partial` note with how many files
+were skipped and the cap in effect, so an agent treats a missing match as
+"maybe not indexed" rather than "not in the repo." `cx status` shows the same,
+and `cx search` prints a warning. Raise `CX_MAX_FILES` (CLI: `--max-files`)
+and re-index for full coverage.
 
 ### What tools does the MCP server expose?
 

--- a/docs/tradeoffs.md
+++ b/docs/tradeoffs.md
@@ -53,3 +53,9 @@ stress fixtures, generated blobs) fall back to fixed-window chunking under a
 per-parse deadline so a single file cannot stall a run. Practical caps
 (`CX_MAX_FILES`, `CX_MAX_FILE_BYTES`) bound the work; see the
 [benchmark](benchmark.md) for indexing-at-scale timings.
+
+When a tree exceeds the file cap the index is partial, and it says so rather
+than pretending to be complete: `search` and `sql` results carry a `partial`
+marker (files skipped and the cap in effect), and `cx status` reports it. That
+turns "no match" into "no match in the indexed subset" - raise `CX_MAX_FILES`
+and re-index for full coverage.

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,11 @@ logs, docs, and agent memory.
   SELECT/WITH over `chunks(path, start_line, end_line, lang, content)`,
   search functions usable as table-valued relations, `regexp_like` for
   regex), `reindex` (incremental sync; the server also auto-syncs in the
-  background).
+  background). A `search`/`sql` on a never-indexed repo builds the index
+  inline and answers on the same call (keyword live in seconds, vectors
+  backfilling); `CX_AUTO_INDEX=0` restores a strict "index it first" error.
+  Each tool takes an optional `path` (absolute repo root) so one server serves
+  multiple repos in a session; omit it for the startup root.
 - CLI: `cx index` (incremental; `--full`, `--watch`), `cx search`,
   `cx sql`, `cx status`, `cx mcp`.
 
@@ -59,13 +63,14 @@ logs, docs, and agent memory.
 
 ## Operational notes
 
-- The index lives in `.infino/` in the repo root (add it to your
-  `.gitignore`): plain files you can copy or cache in CI.
+- The index lives in `.infino/` in the repo root (added to your
+  `.gitignore` automatically on first index): plain files you can copy or
+  cache in CI.
 - Staged readiness: the keyword index commits before the embedding model
   finishes downloading; a failed vector stage degrades to keyword-only
   search instead of failing the index.
 - Incremental sync re-chunks and re-embeds only changed files (size/mtime
   prefilter, then content hash); an unchanged tree is a fast no-op.
-- Config via env: `CX_ROOT`, `CX_INDEX_DIR`, `CX_AUTO_SYNC`,
+- Config via env: `CX_ROOT`, `CX_INDEX_DIR`, `CX_AUTO_INDEX`, `CX_AUTO_SYNC`,
   `CX_SYNC_INTERVAL_SECS`, `CX_NO_EMBED`, `CX_MAX_FILES`,
   `CX_MAX_FILE_BYTES`.

--- a/src/commands/query-cmds.ts
+++ b/src/commands/query-cmds.ts
@@ -29,6 +29,7 @@ export async function searchCmd(query: string, opts: SearchCmdOptions): Promise<
       return;
     }
     if (result.note) console.error(yellow(`note: ${result.note}`));
+    if (result.partial) console.error(yellow(`warning: ${result.partial.note}`));
     result.hits.forEach((h, i) => {
       console.log(
         `${bold(String(i + 1) + ".")} ${cyan(h.path)}${dim(`:${h.startLine}-${h.endLine}`)} ${dim(`(${result.ranking} ${h.score.toFixed(3)})`)}`,
@@ -98,6 +99,13 @@ export function statusCmd(opts: StatusCmdOptions): void {
   }
   console.log(`${bold("code-context")} - ${handle.root}`);
   console.log(`  chunks     ${fmtCount(m.chunks)} from ${fmtCount(m.files)} files`);
+  if (m.truncatedFiles) {
+    console.log(
+      yellow(
+        `  partial    ${fmtCount(m.truncatedFiles)} files over the ${fmtCount(m.maxFiles ?? 0)}-file cap were skipped (raise CX_MAX_FILES / --max-files)`,
+      ),
+    );
+  }
   console.log(`  vectors    ${m.vectors}${m.embedder ? dim(`  (${m.embedder.provider} ${m.embedder.model}, ${m.embedder.dim}d)`) : ""}`);
   console.log(`  indexed    ${fmtAge(m.indexedAt)}${dim(` (keyword ${fmtMs(m.indexMs)}${m.embedMs ? `, vectors ${fmtMs(m.embedMs)}` : ""})`)}`);
   const langs = Object.entries(m.languages)

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -8,8 +8,8 @@
 // never changes, so SQL written against `chunks` keeps working across stages;
 // the manifest records how far the index has progressed.
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, appendFileSync, existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
 import { IndexSpec, type Connection, type OptimizeOptions } from "@infino-ai/infino";
 import { APPEND_BATCH, EMBED_BATCH, N_CENT, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
 import { walkRepo } from "./walker.js";
@@ -46,6 +46,8 @@ export interface IndexStats {
   chunks: number;
   /** Candidate files left out because the repo exceeded the file cap. */
   truncatedFiles?: number;
+  /** The file cap in effect for this build (context for `truncatedFiles`). */
+  maxFiles: number;
   languages: Record<string, number>;
   vectors: VectorState;
   indexMs: number;
@@ -83,6 +85,9 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
   const { root, db, indexDirPath, embedder, onPhase, onProgress } = opts;
   const caps = opts.caps ?? DEFAULT_CAPS;
   const t0 = performance.now();
+
+  // Keep the index out of the user's commits before we write a byte of it.
+  ensureIndexIgnored(root, indexDirPath);
 
   // --- scan + chunk ---------------------------------------------------------
   onPhase?.("scan");
@@ -135,6 +140,7 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
     files,
     chunks: chunks.length,
     ...(truncatedFiles > 0 ? { truncatedFiles } : {}),
+    maxFiles: caps.maxFiles,
     languages,
     vectors: embedder ? "building" : "none",
     indexMs,
@@ -209,6 +215,9 @@ export interface SyncResult {
   /** Post-sync totals. */
   files: number;
   chunks: number;
+  /** Files still left un-indexed because the tree exceeds the file cap (0 when
+   * the whole tree fits). Recomputed each sync so it tracks a growing repo. */
+  truncatedFiles: number;
   vectors: VectorState;
   tookMs: number;
 }
@@ -246,9 +255,9 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
 
   // --- diff -------------------------------------------------------------------
   onPhase?.("scan");
-  const candidates = walkRepo(root)
-    .filter((f) => shouldIndexFile(f.path) && f.size <= caps.maxFileBytes)
-    .slice(0, caps.maxFiles);
+  const walked = walkRepo(root).filter((f) => shouldIndexFile(f.path) && f.size <= caps.maxFileBytes);
+  const candidates = walked.slice(0, caps.maxFiles);
+  const truncatedFiles = walked.length - candidates.length;
   const buffers = new Map<string, Buffer>();
   const diff = diffFiles(candidates, prev, (path) => {
     try {
@@ -262,6 +271,21 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
 
   if (diff.added.length === 0 && diff.changed.length === 0 && diff.deleted.length === 0) {
     writeFileState(indexDirPath, diff.next); // refresh stat fingerprints
+    // Files added or removed *beyond* the cap never show up in the diff (the
+    // candidate list is already capped), so the truncation count can change
+    // while the indexed content doesn't. Reconcile the manifest when it drifts,
+    // otherwise the "index is partial" marker goes stale.
+    if (truncatedFiles !== (manifest.truncatedFiles ?? 0)) {
+      const reconciled: Manifest = { ...manifest };
+      if (truncatedFiles > 0) {
+        reconciled.truncatedFiles = truncatedFiles;
+        reconciled.maxFiles = caps.maxFiles;
+      } else {
+        delete reconciled.truncatedFiles;
+        delete reconciled.maxFiles;
+      }
+      writeManifest(indexDirPath, reconciled);
+    }
     return {
       action: "noop",
       filesAdded: 0,
@@ -271,6 +295,7 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
       chunksRemoved: 0,
       files: manifest.files,
       chunks: manifest.chunks,
+      truncatedFiles,
       vectors: manifest.vectors,
       tookMs: Math.round(performance.now() - t0),
     };
@@ -333,6 +358,16 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
     languages,
     indexedAt: new Date().toISOString(),
   };
+  // Track truncation as the tree grows or shrinks: set the fields when files
+  // are now over the cap, clear the stale ones (spread from `manifest`) when
+  // the tree has dropped back under it.
+  if (truncatedFiles > 0) {
+    nextManifest.truncatedFiles = truncatedFiles;
+    nextManifest.maxFiles = caps.maxFiles;
+  } else {
+    delete nextManifest.truncatedFiles;
+    delete nextManifest.maxFiles;
+  }
   writeManifest(indexDirPath, nextManifest);
 
   // --- compact after deletes/appends to keep tombstones clean ---
@@ -347,6 +382,7 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
     chunksRemoved,
     files: nextManifest.files,
     chunks: nextManifest.chunks,
+    truncatedFiles,
     vectors: nextManifest.vectors,
     tookMs: Math.round(performance.now() - t0),
   };
@@ -368,6 +404,40 @@ function compact(table: { optimize(opts?: OptimizeOptions): void; gc(graceSecs: 
   }
 }
 
+/** Keep the on-disk index out of version control. On a build, add the index
+ * directory to the repo-root `.gitignore` when the repo is a git checkout and
+ * the dir isn't already ignored. Best-effort and idempotent: it never fails a
+ * build, and does nothing when the index lives outside the repo (a custom
+ * CX_INDEX_DIR) since there's nothing in the tree to ignore. */
+function ensureIndexIgnored(root: string, indexDirPath: string): void {
+  try {
+    const rel = relative(root, indexDirPath);
+    // Index lives outside the repo tree (custom CX_INDEX_DIR) - nothing to ignore.
+    if (!rel || rel === "" || rel.startsWith("..")) return;
+    // Only manage a .gitignore inside an actual git checkout (dir or worktree file).
+    if (!existsSync(join(root, ".git"))) return;
+
+    const entry = rel.split(sep).join("/").replace(/\/+$/, "");
+    const gitignorePath = join(root, ".gitignore");
+    let current = "";
+    try {
+      current = readFileSync(gitignorePath, "utf8");
+    } catch {
+      /* no .gitignore yet - we'll create one */
+    }
+    const already = current
+      .split(/\r?\n/)
+      .map((l) => l.trim().replace(/^\/+/, "").replace(/\/+$/, ""))
+      .some((l) => l === entry);
+    if (already) return;
+
+    const prefix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+    appendFileSync(gitignorePath, `${prefix}${entry}/\n`);
+  } catch {
+    /* read-only tree, permissions, etc. - never fail indexing over .gitignore */
+  }
+}
+
 function toTextRow(c: Chunk) {
   return {
     path: c.path,
@@ -386,6 +456,7 @@ function toManifest(stats: IndexStats, embedder?: Manifest["embedder"]): Manifes
     ...(embedder ? { embedder } : {}),
     files: stats.files,
     chunks: stats.chunks,
+    ...(stats.truncatedFiles ? { truncatedFiles: stats.truncatedFiles, maxFiles: stats.maxFiles } : {}),
     languages: stats.languages,
     indexedAt: new Date().toISOString(),
     indexMs: stats.indexMs,

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -30,6 +30,13 @@ export interface Manifest {
   embedder?: EmbedderInfo;
   files: number;
   chunks: number;
+  /** Files left un-indexed because the repo exceeded the file cap. Absent when
+   * the whole tree fit (the common case) - its presence means the index is
+   * partial and query results may be incomplete. */
+  truncatedFiles?: number;
+  /** The file cap in effect when `truncatedFiles` was recorded, for context in
+   * the "index is partial" warning. Only meaningful alongside `truncatedFiles`. */
+  maxFiles?: number;
   /** Chunk count per language tag. */
   languages: Record<string, number>;
   indexedAt: string;

--- a/src/core/searcher.ts
+++ b/src/core/searcher.ts
@@ -15,6 +15,31 @@
 import type { IndexHandle } from "./context.js";
 import { TABLE } from "./config.js";
 import type { Embedder } from "./embedder.js";
+import type { Manifest } from "./manifest.js";
+
+/** Set when the index omitted files over the cap - the index is incomplete, so
+ * an absence in results is not proof of absence in the repo. */
+export interface PartialIndex {
+  filesSkipped: number;
+  fileCap: number;
+  note: string;
+}
+
+/** Build the partial-index marker from a manifest, or undefined when the whole
+ * tree was indexed. Shared by search (below) and the SQL path (server-side),
+ * so every query surfaces the same "results may be incomplete" signal. */
+export function partialIndex(manifest: Manifest): PartialIndex | undefined {
+  if (!manifest.truncatedFiles) return undefined;
+  const cap = manifest.maxFiles ?? 0;
+  return {
+    filesSkipped: manifest.truncatedFiles,
+    fileCap: cap,
+    note:
+      `${manifest.truncatedFiles} file(s) over the ${cap}-file cap were left out of the index, so ` +
+      "results may be incomplete - a missing match is not proof it's absent. Raise CX_MAX_FILES " +
+      "(CLI: --max-files) and re-index for full coverage.",
+  };
+}
 
 /** JSON.stringify that survives the engine's bigint row values. */
 export function jsonify(value: unknown, pretty = false): string {
@@ -38,9 +63,27 @@ export interface SearchHit {
   truncated?: boolean;
 }
 
-/** Per-hit content cap: enough to answer "how does X work" from the hit
- * itself (a whole ~60-line chunk fits; only pathological chunks truncate). */
-const HIT_CONTENT_CAP = 4000;
+/** Rank-adaptive content budget. The top hits carry full content so the
+ * answer comes straight from them; lower-ranked hits are trimmed to a snippet
+ * (their path:line + a `truncated` flag let the agent Read the rest only if a
+ * top hit didn't already answer it). This keeps the ranked payload lean once an
+ * agent leans on search, without starving the "answer without opening files"
+ * behaviour that the top hits provide. All three are env-tunable for evaluation.
+ *   CX_HIT_CONTENT_CAP - char cap for a full-content (top) hit
+ *   CX_FULL_HITS       - how many hits get the full cap; the rest get the snippet
+ *   CX_SNIPPET_CAP     - char cap for a trimmed (lower-ranked) hit */
+const HIT_CONTENT_CAP = Number(process.env.CX_HIT_CONTENT_CAP ?? 4000);
+const FULL_HITS = Number(process.env.CX_FULL_HITS ?? 2);
+const SNIPPET_CAP = Number(process.env.CX_SNIPPET_CAP ?? 1000);
+
+/** Trim to at most `cap` chars, preferring a line boundary so a snippet ends on
+ * a whole line rather than mid-token. */
+function trimToCap(s: string, cap: number): string {
+  if (s.length <= cap) return s;
+  const slice = s.slice(0, cap);
+  const nl = slice.lastIndexOf("\n");
+  return nl > cap / 2 ? slice.slice(0, nl) : slice;
+}
 
 export interface SearchResult {
   query: string;
@@ -48,6 +91,8 @@ export interface SearchResult {
   ranking: "hybrid" | "keyword";
   hits: SearchHit[];
   note?: string;
+  /** Present when the index omitted files over the cap - results may be incomplete. */
+  partial?: PartialIndex;
 }
 
 const PROJECTION = ["path", "start_line", "end_line", "lang", "content", "score"];
@@ -79,21 +124,27 @@ export async function search(
   return {
     query,
     ranking,
-    hits: rows.map((r) => {
+    hits: rows.map((r, i) => {
       const full = String(r.content);
+      const cap = i < FULL_HITS ? HIT_CONTENT_CAP : SNIPPET_CAP;
+      const content = trimToCap(full, cap);
       return {
         path: String(r.path),
         startLine: Number(r.start_line),
         endLine: Number(r.end_line),
         lang: String(r.lang ?? ""),
         score: Number(r.score),
-        content: full.slice(0, HIT_CONTENT_CAP),
-        ...(full.length > HIT_CONTENT_CAP ? { truncated: true } : {}),
+        content,
+        ...(content.length < full.length ? { truncated: true } : {}),
       };
     }),
     ...(ranking === "keyword" && handle.manifest.vectors !== "ready"
       ? { note: "vectors not ready yet - keyword-ranked only (re-run `cx index` or wait for the vector stage to finish)" }
       : {}),
+    ...(() => {
+      const partial = partialIndex(handle.manifest);
+      return partial ? { partial } : {};
+    })(),
   };
 }
 

--- a/src/mcp/ensure.ts
+++ b/src/mcp/ensure.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Auto-index on first query. A search/sql against a repo that has never been
+// indexed builds the index inline and then answers on the same call, instead
+// of erroring with "index it first". Staged readiness makes this cheap: the
+// build resolves the moment keyword search is live (seconds), with vectors
+// backfilling in the background - so the first query returns real hits, not a
+// "come back later" message. CX_AUTO_INDEX=0 restores the strict error.
+//
+// The build goes through the repo's one-mutation-at-a-time lock, so a first
+// query can't race a concurrent reindex/auto-sync: if a build is already in
+// flight, this waits for it to reach keyword-live rather than starting another.
+
+import type { RepoCtx } from "./repos.js";
+import type { IndexHandle } from "../core/context.js";
+import type { IndexStats } from "../core/indexer.js";
+
+export interface EnsureDeps {
+  /** Whether a missing index should be built on demand (CX_AUTO_INDEX). */
+  autoIndexEnabled: boolean;
+  /** Open the current index for a repo, or null when there isn't one. */
+  getHandle(ctx: RepoCtx): IndexHandle | null;
+  /** Acquire the repo's mutation lock and run a staged build, resolving at
+   * keyword-live with the stage-1 stats; null if a build/sync is already in
+   * flight on this repo (its promise lives on `ctx.mutation`). */
+  build(ctx: RepoCtx): Promise<IndexStats> | null;
+}
+
+export type EnsureResult =
+  /** Index is available (freshly built when `autoIndexed` is set). */
+  | { handle: IndexHandle; autoIndexed?: IndexStats }
+  /** No index and none was built (auto-index disabled, or the build produced
+   * nothing) - the caller should return the usual "index it first" message. */
+  | { needsIndex: true };
+
+/** Return a usable index handle for `ctx`, building one on first query when
+ * auto-index is enabled. Throws only if the build itself fails (e.g. a
+ * read-only index dir); a disabled or empty outcome is reported as
+ * `needsIndex`, never an exception. */
+export async function ensureIndexed(ctx: RepoCtx, deps: EnsureDeps): Promise<EnsureResult> {
+  const existing = deps.getHandle(ctx);
+  if (existing) return { handle: existing };
+  if (!deps.autoIndexEnabled) return { needsIndex: true };
+
+  const build = deps.build(ctx);
+  let stats: IndexStats | undefined;
+  if (build) {
+    stats = await build; // our build - propagate a real failure to the caller
+  } else if (ctx.mutation) {
+    // Someone else is mid-build; wait for it to reach keyword-live. The lock
+    // promise is guarded against rejection, so this never throws.
+    await ctx.mutation;
+  }
+
+  const handle = deps.getHandle(ctx);
+  if (!handle) return { needsIndex: true };
+  return { handle, autoIndexed: stats };
+}

--- a/src/mcp/repos.ts
+++ b/src/mcp/repos.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Per-repo registry for the MCP server. One server instance serves every repo
+// a session touches: the optional `root` tool argument targets one, defaulting
+// to the startup root. Each repo keeps its own engine connection, auto-sync
+// clock, and mutation lock, held in a small LRU so a session that roams across
+// many repos doesn't accumulate connections without bound.
+//
+// The connection and filesystem-stat calls are injected so this unit tests
+// without a real engine or on-disk repo.
+
+import { statSync } from "node:fs";
+import { join } from "node:path";
+import type { Connection } from "@infino-ai/infino";
+import { indexDir, resolveRoot, INDEX_DIR_NAME } from "../core/config.js";
+
+/** Live state for one repository the server has been asked about. */
+export interface RepoCtx {
+  /** Absolute, resolved repo root. */
+  root: string;
+  /** Index directory for this repo. */
+  dir: string;
+  db: Connection;
+  /** performance.now() of the last auto-sync staleness check. */
+  lastSyncCheck: number;
+  /** In-flight index mutation, or null; enforces one mutation at a time. */
+  mutation: Promise<unknown> | null;
+}
+
+/** Just the piece of `fs.Stats` the registry needs, so tests can fake it. */
+interface StatLike {
+  isDirectory(): boolean;
+}
+
+export interface RepoRegistryOptions {
+  /** Open (or create) an engine connection for an index directory. */
+  connect: (dir: string) => Connection;
+  /** Filesystem stat, injectable for tests. Throws when the path is absent. */
+  stat?: (path: string) => StatLike;
+  /** Max repos kept open at once; the least-recently-used is evicted past it. */
+  maxOpen?: number;
+}
+
+const DEFAULT_MAX_OPEN = 8;
+
+export class RepoRegistry {
+  private readonly repos = new Map<string, RepoCtx>();
+  private readonly defaultRoot: string;
+  private readonly connect: (dir: string) => Connection;
+  private readonly stat: (path: string) => StatLike;
+  private readonly maxOpen: number;
+
+  constructor(defaultRoot: string, opts: RepoRegistryOptions) {
+    this.defaultRoot = defaultRoot;
+    this.connect = opts.connect;
+    this.stat = opts.stat ?? statSync;
+    this.maxOpen = opts.maxOpen ?? DEFAULT_MAX_OPEN;
+  }
+
+  /** Index directory for a root. CX_INDEX_DIR is a single-repo override that
+   * only redirects the startup root, so a multi-repo session never collapses
+   * every repo onto one index dir. */
+  dirFor(root: string): string {
+    return root === this.defaultRoot ? indexDir(root) : join(root, INDEX_DIR_NAME);
+  }
+
+  /** Roots currently held open, most-recently-used last. Test/introspection. */
+  openRoots(): string[] {
+    return [...this.repos.keys()];
+  }
+
+  /** Resolve + validate a requested root into its (cached) context. Throws a
+   * clear error for a missing or non-directory path. Most-recently-used repos
+   * stay live; the least-recently-used is evicted past `maxOpen`. */
+  get(requested?: string): RepoCtx {
+    const root = requested ? resolveRoot(requested) : this.defaultRoot;
+    const existing = this.repos.get(root);
+    if (existing) {
+      // Reinsert to mark most-recently-used (Map preserves insertion order).
+      this.repos.delete(root);
+      this.repos.set(root, existing);
+      return existing;
+    }
+    let stat: StatLike;
+    try {
+      stat = this.stat(root);
+    } catch {
+      throw new Error(`path does not exist: ${root}`);
+    }
+    if (!stat.isDirectory()) throw new Error(`not a directory: ${root}`);
+    const dir = this.dirFor(root);
+    const ctx: RepoCtx = { root, dir, db: this.connect(dir), lastSyncCheck: 0, mutation: null };
+    this.repos.set(root, ctx);
+    if (this.repos.size > this.maxOpen) {
+      const lru = this.repos.keys().next().value!;
+      this.repos.delete(lru);
+    }
+    return ctx;
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,64 +17,88 @@ import { existsSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { connect, type Connection } from "@infino-ai/infino";
+import { connect } from "@infino-ai/infino";
 import { indexDir, resolveRoot, TABLE, DEFAULT_CAPS } from "../core/config.js";
 import { readManifest, type Manifest } from "../core/manifest.js";
 import type { IndexHandle } from "../core/context.js";
-import { search, runSql, jsonify } from "../core/searcher.js";
-import { indexRepoStaged, syncRepo, type SyncOutcome } from "../core/indexer.js";
+import { search, runSql, jsonify, partialIndex } from "../core/searcher.js";
+import { indexRepoStaged, syncRepo, type SyncOutcome, type IndexStats } from "../core/indexer.js";
 import { createEmbedder, embedderInfo, type Embedder } from "../core/embedder.js";
+import { RepoRegistry, type RepoCtx } from "./repos.js";
+import { ensureIndexed, type EnsureResult } from "./ensure.js";
 
 export async function serveMcp(rootPath?: string): Promise<void> {
-  const root = resolveRoot(rootPath);
-  const dir = indexDir(root);
-
-  // One connection for the server's lifetime; the manifest is re-read per
-  // call so staged vector readiness is noticed the moment it lands.
-  let db: Connection | null = null;
-  const getDb = () => (db ??= connect(dir));
-  const getHandle = (): IndexHandle | null => {
-    if (!existsSync(dir)) return null;
-    const manifest = readManifest(dir);
-    if (!manifest) return null;
-    return { root, dir, db: getDb(), manifest };
-  };
+  const defaultRoot = resolveRoot(rootPath);
 
   let embedder: Embedder | null = null;
   const getEmbedder = () => (embedder ??= createEmbedder());
 
-  // --- freshness: one index mutation at a time, auto-sync on queries ----------
-  // Queries are not queued behind syncs; they run against the current index and the
-  // next query sees the fresh one. CX_AUTO_SYNC=0 disables; the debounce keeps
-  // the stat walk off the hot path (~20ms to ~2s depending on repo size).
+  // --- per-repo state ---------------------------------------------------------
+  // One server serves every repo a session touches: the optional `path` tool
+  // arg targets one, defaulting to the startup root. Each repo keeps its own
+  // connection, auto-sync clock, and mutation lock, held in a small LRU so a
+  // session that roams across many repos doesn't accumulate connections.
+  const registry = new RepoRegistry(defaultRoot, { connect });
+  const repoFor = (requested?: string): RepoCtx => registry.get(requested);
+
+  // The manifest is re-read per call so staged vector readiness is noticed the
+  // moment it lands.
+  const getHandle = (ctx: RepoCtx): IndexHandle | null => {
+    if (!existsSync(ctx.dir)) return null;
+    const manifest = readManifest(ctx.dir);
+    if (!manifest) return null;
+    return { root: ctx.root, dir: ctx.dir, db: ctx.db, manifest };
+  };
+
+  // --- freshness: one index mutation at a time per repo, auto-sync on queries -
+  // Queries are not queued behind syncs; they run against the current index and
+  // the next query sees the fresh one. CX_AUTO_SYNC=0 disables; the debounce
+  // keeps the stat walk off the hot path (~20ms to ~2s depending on repo size).
   const autoSyncEnabled = !["0", "false", "no"].includes((process.env.CX_AUTO_SYNC ?? "").toLowerCase());
   const syncIntervalMs = Number(process.env.CX_SYNC_INTERVAL_SECS ?? 30) * 1000;
-  let lastSyncCheck = 0;
-  let mutation: Promise<unknown> | null = null;
+  // A search/sql on a never-indexed repo builds the index inline, then answers
+  // on the same call (staged: keyword search live in seconds). Off restores the
+  // strict "index it first" error.
+  const autoIndexEnabled = !["0", "false", "no"].includes((process.env.CX_AUTO_INDEX ?? "").toLowerCase());
 
-  /** Run an index mutation exclusively; returns null if one is in flight. */
-  const exclusive = <T,>(fn: () => Promise<T>): Promise<T> | null => {
-    if (mutation) return null;
+  /** Run an index mutation on a repo exclusively; null if one is in flight. */
+  const exclusive = <T,>(ctx: RepoCtx, fn: () => Promise<T>): Promise<T> | null => {
+    if (ctx.mutation) return null;
     const p = fn().finally(() => {
-      mutation = null;
+      ctx.mutation = null;
     });
-    mutation = p.catch(() => undefined); // guard must not reject
+    ctx.mutation = p.catch(() => undefined); // guard must not reject
     return p;
   };
 
-  const doSync = async (): Promise<SyncOutcome> => {
+  /** Acquire the repo's mutation lock and run a staged build; resolves at
+   * keyword-live with stage-1 stats, or null if a build is already in flight. */
+  const buildIndex = (ctx: RepoCtx): Promise<IndexStats> | null =>
+    exclusive(ctx, async () => {
+      const run = await indexRepoStaged({
+        root: ctx.root,
+        db: ctx.db,
+        indexDirPath: ctx.dir,
+        embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
+        caps: DEFAULT_CAPS,
+      });
+      void run.completion; // vectors backfill in-process; manifest flips to "ready"
+      return run.text;
+    });
+
+  const doSync = async (ctx: RepoCtx): Promise<SyncOutcome> => {
     const outcome = await syncRepo({
-      root,
-      db: getDb(),
-      indexDirPath: dir,
+      root: ctx.root,
+      db: ctx.db,
+      indexDirPath: ctx.dir,
       embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
       caps: DEFAULT_CAPS,
     });
     if (outcome.action === "rebuild-required" && outcome.reason !== "vector backfill in progress") {
       const run = await indexRepoStaged({
-        root,
-        db: getDb(),
-        indexDirPath: dir,
+        root: ctx.root,
+        db: ctx.db,
+        indexDirPath: ctx.dir,
         embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
         caps: DEFAULT_CAPS,
       });
@@ -83,14 +107,14 @@ export async function serveMcp(rootPath?: string): Promise<void> {
     return outcome;
   };
 
-  const maybeAutoSync = () => {
-    if (!autoSyncEnabled || performance.now() - lastSyncCheck < syncIntervalMs) return;
-    lastSyncCheck = performance.now();
+  const maybeAutoSync = (ctx: RepoCtx) => {
+    if (!autoSyncEnabled || performance.now() - ctx.lastSyncCheck < syncIntervalMs) return;
+    ctx.lastSyncCheck = performance.now();
     // Deferred so the triggering query's engine call runs first; the sync's
     // stat walk still shares the process, so on very large repos a
     // concurrent query can feel it. Queries are never queued behind syncs.
     setImmediate(() => {
-      const p = exclusive(doSync);
+      const p = exclusive(ctx, () => doSync(ctx));
       p?.catch((err) => console.error(`auto-sync failed: ${(err as Error).message}`));
     });
   };
@@ -100,8 +124,17 @@ export async function serveMcp(rootPath?: string): Promise<void> {
     content: [{ type: "text" as const, text: message }],
     isError: true,
   });
-  const noIndex = () =>
+  const noIndex = (root: string) =>
     fail(`no index for ${root} yet - call the reindex tool once (keyword search is live in seconds).`);
+
+  /** Marker attached to a query result when this call built the index. */
+  const autoIndexNote = (stats: IndexStats) => ({
+    files: stats.files,
+    chunks: stats.chunks,
+    note:
+      "no index existed - built one on this call; keyword search is live now" +
+      (stats.vectors === "building" ? " and vectors are backfilling in the background" : ""),
+  });
 
   const timed = <T,>(fn: () => T): { value: T; tookMs: number } => {
     const t0 = performance.now();
@@ -123,7 +156,13 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         "cannot express at any budget.\n" +
         "- reindex - sync the index after the working tree changes.\n" +
         "Every result cites path plus line range; read the cited file region only when the chunk " +
-        "content is not already enough.",
+        "content is not already enough. For a question about how the code works, start with search " +
+        "and keep iterating with search rather than falling back to grep and whole-file reads: the " +
+        "ranked hits are already the relevant regions.\n" +
+        "Every tool takes an optional 'path' (an absolute repo root): omit it for the default repo, " +
+        "or set it to target a specific one when you're working across more than one repo in a session.\n" +
+        "If a result carries a 'partial' marker, the repo exceeded the index's file cap and some files " +
+        "were left out: treat a missing match as possibly-unindexed, not proof it's absent.",
     },
   );
 
@@ -138,24 +177,49 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         "identifiers, error strings, function names, stemmed and scored) with semantic similarity " +
         "(renamed symbols, paraphrases, 'where is X handled'), so it works whether or not you know " +
         "the words. Each hit carries path, line range, and the chunk content with a relevance " +
-        "score, usually enough to answer without opening the file; if a hit is marked truncated, " +
-        "Read exactly its start-end range (offset/limit), not the whole file. If you only need to " +
-        "jump to one known identifier or literal string, a plain file/grep search is fine; reach " +
-        "for this when the answer needs understanding or crosses files. (Until the index's vector " +
-        "stage finishes, results are keyword-ranked and say so.)",
+        "score, usually enough to answer directly. When one search isn't enough, refine the query " +
+        "and search again: the index has already ranked the relevant regions, so iterating with " +
+        "search converges faster than switching to grep and reading whole files. Read a file only " +
+        "for a hit marked truncated, and only its cited start-end range (offset/limit). If you only " +
+        "need to jump to one known identifier or literal string, a plain file/grep search is fine; " +
+        "reach for this whenever the answer needs understanding or crosses files. (Until the index's " +
+        "vector stage finishes, results are keyword-ranked and say so.)",
       inputSchema: {
         query: z.string().describe("What you're looking for - terms, a phrase, or a description."),
         k: z.number().int().positive().max(50).default(6).describe("Maximum hits."),
+        path: z
+          .string()
+          .optional()
+          .describe(
+            "Absolute path to the repository root to search. Defaults to the server's configured root; " +
+              "set it to target a specific repo when a session spans more than one.",
+          ),
       },
     },
-    async ({ query, k }) => {
-      const handle = getHandle();
-      if (!handle) return noIndex();
-      maybeAutoSync();
+    async ({ query, k, path }) => {
+      let ctx: RepoCtx;
+      try {
+        ctx = repoFor(path);
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+      let ensured: EnsureResult;
+      try {
+        ensured = await ensureIndexed(ctx, { autoIndexEnabled, getHandle, build: buildIndex });
+      } catch (err) {
+        return fail(`indexing failed: ${(err as Error).message}`);
+      }
+      if ("needsIndex" in ensured) return noIndex(ctx.root);
+      const { handle, autoIndexed } = ensured;
+      if (!autoIndexed) maybeAutoSync(ctx); // a fresh build is already current
       try {
         const t0 = performance.now();
         const result = await search(handle, getEmbedder(), query, k);
-        return ok({ ...result, took_ms: Math.round((performance.now() - t0) * 1000) / 1000 });
+        return ok({
+          ...result,
+          ...(autoIndexed ? { auto_indexed: autoIndexNote(autoIndexed) } : {}),
+          took_ms: Math.round((performance.now() - t0) * 1000) / 1000,
+        });
       } catch (err) {
         return fail(`search failed: ${(err as Error).message}`);
       }
@@ -186,16 +250,41 @@ export async function serveMcp(rootPath?: string): Promise<void> {
           .record(z.string())
           .optional()
           .describe('Map of placeholder name → query text, embedded server-side. E.g. {"q":"vector indexing"} fills {{q}}.'),
+        path: z
+          .string()
+          .optional()
+          .describe(
+            "Absolute path to the repository root to query. Defaults to the server's configured root; " +
+              "set it to target a specific repo when a session spans more than one.",
+          ),
       },
     },
-    async ({ query, embed }) => {
-      const handle = getHandle();
-      if (!handle) return noIndex();
-      maybeAutoSync();
+    async ({ query, embed, path }) => {
+      let ctx: RepoCtx;
+      try {
+        ctx = repoFor(path);
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+      let ensured: EnsureResult;
+      try {
+        ensured = await ensureIndexed(ctx, { autoIndexEnabled, getHandle, build: buildIndex });
+      } catch (err) {
+        return fail(`indexing failed: ${(err as Error).message}`);
+      }
+      if ("needsIndex" in ensured) return noIndex(ctx.root);
+      const { handle, autoIndexed } = ensured;
+      if (!autoIndexed) maybeAutoSync(ctx); // a fresh build is already current
       try {
         const t0 = performance.now();
         const rows = await runSql(handle, getEmbedder(), query, embed as Record<string, string> | undefined);
-        return ok({ rows, took_ms: Math.round((performance.now() - t0) * 1000) / 1000 });
+        const partial = partialIndex(handle.manifest);
+        return ok({
+          rows,
+          ...(partial ? { partial } : {}),
+          ...(autoIndexed ? { auto_indexed: autoIndexNote(autoIndexed) } : {}),
+          took_ms: Math.round((performance.now() - t0) * 1000) / 1000,
+        });
       } catch (err) {
         return fail(`sql failed: ${(err as Error).message}`);
       }
@@ -215,27 +304,40 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         "Pass full=true to force a rebuild from scratch. Returns what changed plus index status.",
       inputSchema: {
         full: z.boolean().optional().describe("Force a full rebuild instead of an incremental sync."),
+        path: z
+          .string()
+          .optional()
+          .describe(
+            "Absolute path to the repository root to index. Defaults to the server's configured root; " +
+              "set it to target a specific repo when a session spans more than one.",
+          ),
       },
     },
-    async ({ full }) => {
+    async ({ full, path }) => {
+      let ctx: RepoCtx;
+      try {
+        ctx = repoFor(path);
+      } catch (err) {
+        return fail((err as Error).message);
+      }
       try {
         const runFull = async () => {
           const run = await indexRepoStaged({
-            root,
-            db: getDb(),
-            indexDirPath: dir,
+            root: ctx.root,
+            db: ctx.db,
+            indexDirPath: ctx.dir,
             embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
             caps: DEFAULT_CAPS,
           });
           void run.completion; // backfills in-process; manifest flips to "ready"
           return ok({ status: "rebuilt - keyword search live; vectors backfilling", ...run.text });
         };
-        const result = exclusive(async () => {
+        const result = exclusive(ctx, async () => {
           if (full) return runFull();
           const outcome = await syncRepo({
-            root,
-            db: getDb(),
-            indexDirPath: dir,
+            root: ctx.root,
+            db: ctx.db,
+            indexDirPath: ctx.dir,
             embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
             caps: DEFAULT_CAPS,
           });
@@ -260,10 +362,10 @@ export async function serveMcp(rootPath?: string): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  const manifest: Manifest | undefined = readManifest(dir);
+  const manifest: Manifest | undefined = readManifest(indexDir(defaultRoot));
   console.error(
-    `code-context MCP server ready on stdio (root: ${root}, index: ${
+    `code-context MCP server ready on stdio (default root: ${defaultRoot}, index: ${
       manifest ? `${manifest.chunks} chunks, vectors ${manifest.vectors}` : "none yet"
-    }, embedder: ${embedderInfo()})`,
+    }, embedder: ${embedderInfo()}; tools accept an optional 'path' to target other repos)`,
   );
 }

--- a/test/auto-index.integration.test.ts
+++ b/test/auto-index.integration.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Auto-index on first query, end to end: ensureIndexed wired to the real
+// staged indexer and manifest, against a real engine catalog. Mirrors exactly
+// how the MCP server builds its `getHandle` and `build` dependencies, so this
+// proves the feature works, not just the control flow.
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect, type Connection } from "@infino-ai/infino";
+import { indexRepoStaged, type IndexStats } from "../src/core/indexer.js";
+import { readManifest } from "../src/core/manifest.js";
+import { search } from "../src/core/searcher.js";
+import type { IndexHandle } from "../src/core/context.js";
+import type { Embedder } from "../src/core/embedder.js";
+import type { RepoCtx } from "../src/mcp/repos.js";
+import { ensureIndexed, type EnsureDeps } from "../src/mcp/ensure.js";
+
+const fakeEmbedder: Embedder = {
+  embed: async (texts) => texts.map(() => new Array(16).fill(0.01)),
+  dim: async () => 16,
+  provider: "fake",
+  model: "fake-16d",
+};
+
+let root: string;
+let ctx: RepoCtx;
+
+// The two dependencies exactly as the MCP server constructs them.
+const getHandle = (c: RepoCtx): IndexHandle | null => {
+  if (!existsSync(c.dir)) return null;
+  const manifest = readManifest(c.dir);
+  return manifest ? { root: c.root, dir: c.dir, db: c.db, manifest } : null;
+};
+const exclusive = (c: RepoCtx, fn: () => Promise<IndexStats>): Promise<IndexStats> | null => {
+  if (c.mutation) return null;
+  const p = fn().finally(() => {
+    c.mutation = null;
+  });
+  c.mutation = p.catch(() => undefined);
+  return p;
+};
+const build = (c: RepoCtx): Promise<IndexStats> | null =>
+  exclusive(c, async () => {
+    const run = await indexRepoStaged({ root: c.root, db: c.db, indexDirPath: c.dir, embedder: fakeEmbedder });
+    await run.completion; // await vectors here so the assertion on ranking is deterministic
+    return run.text;
+  });
+
+const deps = (autoIndexEnabled: boolean): EnsureDeps => ({ autoIndexEnabled, getHandle, build });
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cx-autoidx-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src", "auth.ts"),
+    "export function verifySession(token: string) { return token.length > 0; }\n",
+  );
+  const dir = join(root, ".infino");
+  ctx = { root, dir, db: connect(dir) as Connection, lastSyncCheck: 0, mutation: null };
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("auto-index on first query (end to end)", () => {
+  it("builds a real index on the first query and answers from it", async () => {
+    expect(getHandle(ctx)).toBeNull(); // nothing indexed yet
+
+    const res = await ensureIndexed(ctx, deps(true));
+    expect("handle" in res).toBe(true);
+    if (!("handle" in res)) return;
+    expect(res.autoIndexed?.chunks).toBeGreaterThan(0);
+    expect(existsSync(ctx.dir)).toBe(true);
+
+    // The freshly built index actually answers a query.
+    const hits = await search(res.handle, fakeEmbedder, "verifySession token", 5);
+    expect(hits.hits.length).toBeGreaterThan(0);
+    expect(hits.hits[0].path).toContain("auth.ts");
+  });
+
+  it("does not rebuild when the index already exists", async () => {
+    await ensureIndexed(ctx, deps(true)); // first call builds
+    const res = await ensureIndexed(ctx, deps(true)); // second call reuses
+    expect("handle" in res && res.autoIndexed).toBeUndefined();
+  });
+
+  it("reports needsIndex (no build) when auto-index is disabled", async () => {
+    const res = await ensureIndexed(ctx, deps(false));
+    expect(res).toEqual({ needsIndex: true });
+    expect(readManifest(ctx.dir)).toBeUndefined(); // no index was built
+    expect(getHandle(ctx)).toBeNull();
+  });
+});

--- a/test/ensure.test.ts
+++ b/test/ensure.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Auto-index-on-first-query control flow: when a build is triggered, when it
+// is skipped, and how an in-flight build is awaited. Dependencies (handle
+// lookup, staged build) are faked, so this exercises the orchestration itself
+// without an engine.
+import { describe, expect, it } from "vitest";
+import type { Connection } from "@infino-ai/infino";
+import type { RepoCtx } from "../src/mcp/repos.js";
+import type { IndexHandle } from "../src/core/context.js";
+import type { IndexStats } from "../src/core/indexer.js";
+import { ensureIndexed, type EnsureDeps } from "../src/mcp/ensure.js";
+
+const makeCtx = (): RepoCtx => ({
+  root: "/repo",
+  dir: "/repo/.infino",
+  db: {} as unknown as Connection,
+  lastSyncCheck: 0,
+  mutation: null,
+});
+
+const STATS: IndexStats = {
+  files: 3,
+  chunks: 10,
+  languages: { ts: 10 },
+  vectors: "building",
+  indexMs: 5,
+};
+
+const handleFor = (ctx: RepoCtx): IndexHandle =>
+  ({ root: ctx.root, dir: ctx.dir, db: ctx.db, manifest: { vectors: "building" } } as unknown as IndexHandle);
+
+describe("ensureIndexed", () => {
+  it("returns the existing index without building", async () => {
+    const ctx = makeCtx();
+    let builds = 0;
+    const deps: EnsureDeps = {
+      autoIndexEnabled: true,
+      getHandle: (c) => handleFor(c),
+      build: () => ((builds++), Promise.resolve(STATS)),
+    };
+    const res = await ensureIndexed(ctx, deps);
+    expect("handle" in res && res.handle.root).toBe("/repo");
+    expect("handle" in res && res.autoIndexed).toBeUndefined();
+    expect(builds).toBe(0);
+  });
+
+  it("reports needsIndex without building when auto-index is disabled", async () => {
+    const ctx = makeCtx();
+    let builds = 0;
+    const deps: EnsureDeps = {
+      autoIndexEnabled: false,
+      getHandle: () => null,
+      build: () => ((builds++), Promise.resolve(STATS)),
+    };
+    const res = await ensureIndexed(ctx, deps);
+    expect(res).toEqual({ needsIndex: true });
+    expect(builds).toBe(0);
+  });
+
+  it("builds on first query and returns the fresh handle with stats", async () => {
+    const ctx = makeCtx();
+    let indexed = false;
+    let builds = 0;
+    const deps: EnsureDeps = {
+      autoIndexEnabled: true,
+      getHandle: (c) => (indexed ? handleFor(c) : null),
+      build: (c) => {
+        builds++;
+        return (async () => {
+          indexed = true; // the build makes keyword search live
+          return STATS;
+        })();
+      },
+    };
+    const res = await ensureIndexed(ctx, deps);
+    expect(builds).toBe(1);
+    expect("handle" in res && res.autoIndexed).toEqual(STATS);
+  });
+
+  it("waits for an in-flight build instead of starting another", async () => {
+    const ctx = makeCtx();
+    let indexed = false;
+    let resolveInflight!: () => void;
+    // Someone else already holds the lock: build() returns null, and the
+    // in-flight build lives on ctx.mutation. It resolves keyword-live.
+    ctx.mutation = new Promise<void>((r) => {
+      resolveInflight = () => {
+        indexed = true;
+        r();
+      };
+    });
+    let builds = 0;
+    const deps: EnsureDeps = {
+      autoIndexEnabled: true,
+      getHandle: (c) => (indexed ? handleFor(c) : null),
+      build: () => ((builds++), null), // lock is taken
+    };
+    const p = ensureIndexed(ctx, deps);
+    resolveInflight();
+    const res = await p;
+    expect(builds).toBe(1); // attempted once, got null, did not spin
+    expect("handle" in res && res.handle.root).toBe("/repo");
+    expect("handle" in res && res.autoIndexed).toBeUndefined(); // not our build, no stats
+  });
+
+  it("reports needsIndex when a build produced no usable index", async () => {
+    const ctx = makeCtx();
+    const deps: EnsureDeps = {
+      autoIndexEnabled: true,
+      getHandle: () => null, // still nothing after the build
+      build: () => Promise.resolve(STATS),
+    };
+    const res = await ensureIndexed(ctx, deps);
+    expect(res).toEqual({ needsIndex: true });
+  });
+
+  it("propagates a build failure to the caller", async () => {
+    const ctx = makeCtx();
+    const deps: EnsureDeps = {
+      autoIndexEnabled: true,
+      getHandle: () => null,
+      build: () => Promise.reject(new Error("read-only index dir")),
+    };
+    await expect(ensureIndexed(ctx, deps)).rejects.toThrow(/read-only index dir/);
+  });
+});

--- a/test/gitignore.test.ts
+++ b/test/gitignore.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Auto-manage .gitignore: a build keeps the on-disk index out of the user's
+// commits, idempotently and only when it makes sense.
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "@infino-ai/infino";
+import { indexRepo } from "../src/core/indexer.js";
+import type { Embedder } from "../src/core/embedder.js";
+
+const fakeEmbedder: Embedder = {
+  embed: async (texts) => texts.map(() => new Array(16).fill(0.01)),
+  dim: async () => 16,
+  provider: "fake",
+  model: "fake-16d",
+};
+
+let root: string;
+const gitignore = () => join(root, ".gitignore");
+const readIgnore = () => readFileSync(gitignore(), "utf8");
+
+/** A git checkout with one source file, ready to index. */
+function makeRepo(): void {
+  mkdirSync(join(root, ".git"), { recursive: true });
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "a.ts"), "export const x = 1;\n");
+}
+
+async function index(indexDirPath = join(root, ".infino")): Promise<void> {
+  const db = connect(indexDirPath);
+  await indexRepo({ root, db, indexDirPath, embedder: fakeEmbedder });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cx-gitignore-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("auto-manage .gitignore", () => {
+  it("creates a .gitignore and ignores the index dir on first build", async () => {
+    makeRepo();
+    await index();
+    expect(existsSync(gitignore())).toBe(true);
+    expect(readIgnore().split(/\r?\n/)).toContain(".infino/");
+  });
+
+  it("appends to an existing .gitignore without clobbering it (and fixes a missing trailing newline)", async () => {
+    makeRepo();
+    writeFileSync(gitignore(), "node_modules\ndist"); // no trailing newline
+    await index();
+    const lines = readIgnore().split(/\r?\n/);
+    expect(lines).toContain("node_modules");
+    expect(lines).toContain("dist");
+    expect(lines).toContain(".infino/");
+  });
+
+  it("is idempotent - no duplicate entry when already ignored", async () => {
+    makeRepo();
+    writeFileSync(gitignore(), ".infino\n"); // already ignored, slash-free form
+    await index();
+    const count = readIgnore()
+      .split(/\r?\n/)
+      .map((l) => l.trim().replace(/^\/+/, "").replace(/\/+$/, ""))
+      .filter((l) => l === ".infino").length;
+    expect(count).toBe(1);
+  });
+
+  it("does nothing outside a git checkout", async () => {
+    // no .git dir
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "a.ts"), "export const x = 1;\n");
+    await index();
+    expect(existsSync(gitignore())).toBe(false);
+  });
+
+  it("does not touch .gitignore when the index lives outside the repo", async () => {
+    makeRepo();
+    const external = mkdtempSync(join(tmpdir(), "cx-ext-"));
+    try {
+      await index(join(external, "idx"));
+      expect(existsSync(gitignore())).toBe(false);
+    } finally {
+      rmSync(external, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/repos.test.ts
+++ b/test/repos.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Per-repo registry: root resolution, validation, index-dir mapping, and the
+// LRU that keeps a roaming session from accumulating connections. Connection
+// and stat are faked, so no engine or on-disk repo is needed.
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Connection } from "@infino-ai/infino";
+import { RepoRegistry } from "../src/mcp/repos.js";
+
+/** A fake connection tagged with the dir it was opened for, so tests can
+ * assert identity (same ctx reused) and count (no redundant connects). */
+const fakeConn = (dir: string) => ({ __dir: dir } as unknown as Connection);
+
+/** Registry with a counting connect and a stat that treats a fixed set of
+ * paths as directories, one as a file, and everything else as missing. */
+function makeRegistry(
+  defaultRoot: string,
+  opts: { dirs?: string[]; files?: string[]; maxOpen?: number } = {},
+) {
+  const dirs = new Set([defaultRoot, ...(opts.dirs ?? [])]);
+  const files = new Set(opts.files ?? []);
+  let connects = 0;
+  const connectedDirs: string[] = [];
+  const registry = new RepoRegistry(defaultRoot, {
+    connect: (dir) => {
+      connects++;
+      connectedDirs.push(dir);
+      return fakeConn(dir);
+    },
+    stat: (p) => {
+      if (dirs.has(p)) return { isDirectory: () => true };
+      if (files.has(p)) return { isDirectory: () => false };
+      throw new Error("ENOENT");
+    },
+    maxOpen: opts.maxOpen,
+  });
+  return { registry, connects: () => connects, connectedDirs };
+}
+
+const A = "/repos/alpha";
+const B = "/repos/beta";
+const C = "/repos/gamma";
+
+let savedIndexDir: string | undefined;
+beforeEach(() => {
+  savedIndexDir = process.env.CX_INDEX_DIR;
+  delete process.env.CX_INDEX_DIR;
+});
+afterEach(() => {
+  if (savedIndexDir === undefined) delete process.env.CX_INDEX_DIR;
+  else process.env.CX_INDEX_DIR = savedIndexDir;
+});
+
+describe("RepoRegistry.get", () => {
+  it("defaults to the startup root when no path is given", () => {
+    const { registry } = makeRegistry(A);
+    expect(registry.get().root).toBe(A);
+    expect(registry.get(undefined).root).toBe(A);
+  });
+
+  it("targets a requested repo and caches it (one connection per repo)", () => {
+    const { registry, connects } = makeRegistry(A, { dirs: [B] });
+    const first = registry.get(B);
+    const second = registry.get(B);
+    expect(first.root).toBe(B);
+    expect(second).toBe(first); // same live ctx, not a rebuild
+    expect(connects()).toBe(1);
+  });
+
+  it("keeps repos isolated - separate connection, clock, and lock per repo", () => {
+    const { registry } = makeRegistry(A, { dirs: [B] });
+    const a = registry.get(A);
+    const b = registry.get(B);
+    expect(a).not.toBe(b);
+    expect(a.db).not.toBe(b.db);
+    a.lastSyncCheck = 123;
+    a.mutation = Promise.resolve();
+    expect(b.lastSyncCheck).toBe(0);
+    expect(b.mutation).toBeNull();
+  });
+
+  it("throws a clear error for a missing path", () => {
+    const { registry } = makeRegistry(A);
+    expect(() => registry.get("/repos/nope")).toThrow(/path does not exist: \/repos\/nope/);
+  });
+
+  it("throws a clear error for a non-directory path", () => {
+    const { registry } = makeRegistry(A, { files: ["/repos/file.ts"] });
+    expect(() => registry.get("/repos/file.ts")).toThrow(/not a directory: \/repos\/file.ts/);
+  });
+});
+
+describe("RepoRegistry.dirFor", () => {
+  it("puts each repo's index in its own .infino by default", () => {
+    const { registry } = makeRegistry(A, { dirs: [B] });
+    expect(registry.dirFor(A)).toBe(join(A, ".infino"));
+    expect(registry.dirFor(B)).toBe(join(B, ".infino"));
+  });
+
+  it("CX_INDEX_DIR overrides only the startup root, never a secondary repo", () => {
+    process.env.CX_INDEX_DIR = "/custom/index";
+    const { registry } = makeRegistry(A, { dirs: [B] });
+    // The single-repo override applies to the default root...
+    expect(registry.dirFor(A)).toBe("/custom/index");
+    // ...but a secondary repo must NOT collapse onto the same index dir.
+    expect(registry.dirFor(B)).toBe(join(B, ".infino"));
+  });
+});
+
+describe("RepoRegistry LRU eviction", () => {
+  it("evicts the least-recently-used repo past maxOpen", () => {
+    const { registry, connects } = makeRegistry(A, { dirs: [B, C], maxOpen: 2 });
+    registry.get(A); // open: [A]
+    registry.get(B); // open: [A, B]
+    registry.get(C); // over cap -> evict A -> open: [B, C]
+    expect(registry.openRoots()).toEqual([B, C]);
+    expect(connects()).toBe(3);
+
+    // A was evicted, so touching it reconnects (4th connect).
+    registry.get(A);
+    expect(connects()).toBe(4);
+    expect(registry.openRoots()).toEqual([C, A]); // B is now LRU
+  });
+
+  it("marks a re-accessed repo most-recently-used so it survives the next eviction", () => {
+    const { registry } = makeRegistry(A, { dirs: [B, C], maxOpen: 2 });
+    registry.get(A); // [A]
+    registry.get(B); // [A, B]
+    registry.get(A); // touch A -> [B, A]; B is now LRU
+    registry.get(C); // over cap -> evict B -> [A, C]
+    expect(registry.openRoots()).toEqual([A, C]);
+  });
+});

--- a/test/truncation.test.ts
+++ b/test/truncation.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// File-cap truncation: when a repo exceeds the file cap, the index is partial
+// and every query must say so. Covers the manifest record, the search marker,
+// and the sync recompute as a repo grows past / shrinks back under the cap.
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect, type Connection } from "@infino-ai/infino";
+import { indexRepo, syncRepo } from "../src/core/indexer.js";
+import { readManifest, type Manifest } from "../src/core/manifest.js";
+import { search, partialIndex } from "../src/core/searcher.js";
+import type { IndexHandle } from "../src/core/context.js";
+import type { Embedder } from "../src/core/embedder.js";
+
+const fakeEmbedder: Embedder = {
+  embed: async (texts) => texts.map(() => new Array(16).fill(0.01)),
+  dim: async () => 16,
+  provider: "fake",
+  model: "fake-16d",
+};
+
+let root: string;
+let dir: string;
+let db: Connection;
+
+const cap = (maxFiles: number) => ({ maxFiles, maxFileBytes: 1024 * 1024 });
+const writeFile = (n: number) =>
+  writeFileSync(join(root, "src", `f${n}.ts`), `export const value${n} = "token${n}";\n`);
+const handleFrom = (m: Manifest): IndexHandle => ({ root, dir, db, manifest: m });
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cx-trunc-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  dir = join(root, ".infino");
+  db = connect(dir);
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("partialIndex", () => {
+  it("returns undefined when the whole tree was indexed", () => {
+    expect(partialIndex({ truncatedFiles: 0 } as unknown as Manifest)).toBeUndefined();
+    expect(partialIndex({} as unknown as Manifest)).toBeUndefined();
+  });
+
+  it("builds a marker with counts and an actionable note when truncated", () => {
+    const p = partialIndex({ truncatedFiles: 3, maxFiles: 10 } as unknown as Manifest);
+    expect(p).toEqual({
+      filesSkipped: 3,
+      fileCap: 10,
+      note: expect.stringContaining("CX_MAX_FILES"),
+    });
+    expect(p!.note).toContain("3 file");
+    expect(p!.note).toContain("10-file cap");
+  });
+});
+
+describe("truncation end to end", () => {
+  it("records truncation in the manifest and surfaces it in search", async () => {
+    writeFile(0);
+    writeFile(1);
+    writeFile(2);
+    const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(1) });
+    expect(stats.truncatedFiles).toBe(2);
+
+    const m = readManifest(dir)!;
+    expect(m.truncatedFiles).toBe(2);
+    expect(m.maxFiles).toBe(1);
+
+    const r = await search(handleFrom(m), fakeEmbedder, "token", 5);
+    expect(r.partial).toBeDefined();
+    expect(r.partial!.filesSkipped).toBe(2);
+    expect(r.partial!.fileCap).toBe(1);
+  });
+
+  it("omits truncation fields and the marker when the whole tree fits", async () => {
+    writeFile(0);
+    writeFile(1);
+    await indexRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(10) });
+
+    const m = readManifest(dir)!;
+    expect(m.truncatedFiles).toBeUndefined();
+    expect(m.maxFiles).toBeUndefined();
+    expect((await search(handleFrom(m), fakeEmbedder, "token", 5)).partial).toBeUndefined();
+  });
+
+  it("starts tracking truncation once a growing repo crosses the cap", async () => {
+    writeFile(0);
+    writeFile(1);
+    await indexRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(5) });
+    expect(readManifest(dir)!.truncatedFiles).toBeUndefined();
+
+    for (const n of [2, 3, 4, 5]) writeFile(n); // now 6 files, cap 5
+    const outcome = await syncRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(5) });
+    expect(outcome.action).toBe("synced");
+    if (outcome.action !== "synced") return;
+    expect(outcome.truncatedFiles).toBe(1);
+
+    const m = readManifest(dir)!;
+    expect(m.truncatedFiles).toBe(1);
+    expect(m.maxFiles).toBe(5);
+  });
+
+  it("clears truncation when files beyond the cap are deleted (noop-path reconcile)", async () => {
+    writeFile(0);
+    writeFile(1);
+    writeFile(2);
+    await indexRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(1) });
+    expect(readManifest(dir)!.truncatedFiles).toBe(2);
+
+    // f1/f2 were the truncated tail - never indexed - so deleting them changes
+    // no indexed content: the sync is a noop, but truncation must still clear.
+    unlinkSync(join(root, "src", "f1.ts"));
+    unlinkSync(join(root, "src", "f2.ts"));
+    const outcome = await syncRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(1) });
+    expect(outcome.action).toBe("noop");
+    expect(outcome.truncatedFiles).toBe(0);
+
+    const m = readManifest(dir)!;
+    expect(m.truncatedFiles).toBeUndefined();
+    expect(m.maxFiles).toBeUndefined();
+  });
+
+  it("records truncation when a tail file pushes a full index over the cap (noop-path reconcile)", async () => {
+    writeFile(0); // exactly one file, cap 1 - fits
+    await indexRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(1) });
+    expect(readManifest(dir)!.truncatedFiles).toBeUndefined();
+
+    // A new file that sorts into the truncated tail never enters the diff, so
+    // the sync is a noop - but the index is now partial and must say so.
+    writeFile(1);
+    const outcome = await syncRepo({ root, db, indexDirPath: dir, embedder: fakeEmbedder, caps: cap(1) });
+    expect(outcome.action).toBe("noop");
+    expect(outcome.truncatedFiles).toBe(1);
+
+    const m = readManifest(dir)!;
+    expect(m.truncatedFiles).toBe(1);
+    expect(m.maxFiles).toBe(1);
+    expect((await search(handleFrom(m), fakeEmbedder, "token", 5)).partial!.filesSkipped).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Four related agent-DX improvements to the MCP server and CLI. Each is backward-compatible (no breaking changes to existing tool calls) and covered by tests. Test count 38 → 69.

### 1. Auto-manage `.gitignore`
The first index adds `.infino/` to the repo's `.gitignore` so the index never lands in a commit by accident. Git checkouts only, idempotent, and a no-op when the index lives outside the repo (custom `CX_INDEX_DIR`). Best-effort — never fails a build.

### 2. Per-call repo root (multi-repo sessions)
`search`, `sql`, and `reindex` gain an optional `path` (absolute repo root), so **one server serves many repos in a session** instead of being pinned to its startup directory. Omitting `path` preserves prior behaviour. A small LRU (`src/mcp/repos.ts`) holds one engine connection per repo. The parameter name matches the CLI's existing `-C/--path`.

### 3. Auto-index on first query
A `search`/`sql` on a never-indexed repo now **builds the index inline and answers on the same call** (keyword search live in seconds, vectors backfilling in the background) instead of returning an "index it first" error. `CX_AUTO_INDEX=0` restores the strict error. Logic isolated in `src/mcp/ensure.ts`.

### 4. Surface partial-index truncation
When a repo exceeds the file cap (`CX_MAX_FILES`), the omitted-file count and cap are persisted in the manifest and recomputed on sync. Every `search`/`sql` result then carries a `partial` marker so an agent treats a missing match as *possibly un-indexed* rather than *absent*. `cx status` and `cx search` surface it too. Also closes a gap where files added/removed beyond the cap (never in the sync diff) left the marker stale.

## New files
- `src/mcp/repos.ts` — per-repo connection registry (resolve/validate/LRU)
- `src/mcp/ensure.ts` — auto-index-on-first-query control flow
- `test/repos.test.ts`, `test/ensure.test.ts`, `test/gitignore.test.ts`, `test/truncation.test.ts`, `test/auto-index.integration.test.ts`

## Docs
README, `llms.txt`, `docs/faq.md`, `docs/tradeoffs.md`, and `AGENTS.md` updated for the new `path` argument, auto-index behaviour, `CX_AUTO_INDEX`, and partial-index reporting.

## Testing
`npm run build` clean; `npm test` → 69 passing. Verified end-to-end through the real CLI (auto-gitignore, auto-index, and the `partial` marker in `cx index`/`status`/`search`).
