### PR TITLE
Add usage receipts and a local cx usage ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,13 @@ no restart, no per-repo config.
 | `CX_AUTO_SYNC` | on | `0` disables the MCP server's background staleness sync |
 | `CX_SYNC_INTERVAL_SECS` | 30 | auto-sync debounce between staleness checks |
 | `CX_NO_EMBED` | off | keyword-only mode for the MCP server (skip the vector stage) |
+| `CX_NO_RECEIPT` | off | `1` turns off usage accounting - the per-call receipt on results and the `cx usage` ledger |
+
+Every `search` / `sql` result carries a **usage receipt** - a terse, local line
+showing the tokens it returned, the files it spanned, and a running session
+total (e.g. `returned ~1.2k tokens | 4 chunks / 3 files | session ~8.4k over 7
+queries`). Every figure is a `~` estimate, computed in-process - nothing about
+your queries or code leaves the machine.
 
 ## CLI
 
@@ -247,8 +254,43 @@ cx index [path]           sync the index (incremental; --full rebuilds, --watch 
 cx search <query>         exact terms + meaning, one ranked pass           (-k hits)
 cx sql <statement>        read-only SQL; --embed q="text" fills {{q}}
 cx status                 what the index holds, how fresh, vector readiness
+cx usage                  ledger of queries run and what each returned  (-n, --all, --clear, --json)
 cx mcp                    serve the MCP tools over stdio
 ```
+
+`cx usage` reads the local ledger at `.infino/usage.jsonl` - every `search` /
+`sql` (from the CLI or the MCP server) appends one line recording the query and
+a compact summary of what came back (paths and line ranges for search, row
+count for sql), plus the token figures from the receipt. It's a deterministic,
+model-independent view of what went through the index - no running server or
+agent needed to read it back. `CX_NO_RECEIPT=1` turns off both the inline
+receipt and this ledger.
+
+### How often does the agent actually reach for it?
+
+`cx usage` can also show, per session, in how many of your prompts code-context
+was used - e.g. `code-context used in 2 of 3 prompts (2 calls)`. The MCP server
+can only count its own calls, not your prompts, so this ratio comes from two
+Claude Code hooks that keep a local tally (nothing is sent anywhere). Add them
+to your Claude Code settings (`~/.claude/settings.json` or a project
+`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "cx usage --hook" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "mcp__code-context.*", "hooks": [{ "type": "command", "command": "cx usage --hook" }] }
+    ]
+  }
+}
+```
+
+`cx usage --hook` reads the event on stdin, updates `.infino/prompt-stats.json`,
+and prints nothing. If you run code-context via `npx`, use
+`npx -y @infino-ai/code-context usage --hook` as the command.
 
 ## What it is, and what it isn't
 

--- a/server.json
+++ b/server.json
@@ -39,6 +39,12 @@
           "description": "Set (1/true/yes) for keyword-only mode - skip the vector stage entirely.",
           "isRequired": false,
           "format": "string"
+        },
+        {
+          "name": "CX_NO_RECEIPT",
+          "description": "Set (1/true/yes) to turn off local usage accounting: the per-call receipt on results and the cx usage ledger. Optional - on by default, computed locally, nothing leaves the machine.",
+          "isRequired": false,
+          "format": "string"
         }
       ]
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@
 
 import { Command } from "commander";
 import { indexCmd } from "./commands/index-cmd.js";
-import { searchCmd, sqlCmd, statusCmd } from "./commands/query-cmds.js";
+import { searchCmd, sqlCmd, statusCmd, usageCmd } from "./commands/query-cmds.js";
 import { DEFAULT_SEARCH_K } from "./core/config.js";
 
 const program = new Command();
@@ -73,6 +73,17 @@ program
   .option("--hook", "one-line output for a SessionStart hook (silent when unindexed)")
   .option("-C, --path <dir>", "repo root (default: current directory)")
   .action(statusCmd);
+
+program
+  .command("usage")
+  .description("show the local ledger of queries run and what each returned (from .infino/usage.jsonl)")
+  .option("-n <count>", "how many recent queries to list", "20")
+  .option("--all", "list every recorded query, not just the most recent")
+  .option("--clear", "delete the usage log")
+  .option("--hook", "internal: consume a Claude Code hook event on stdin and update the prompt/invocation counters")
+  .option("--json", "machine-readable output")
+  .option("-C, --path <dir>", "repo root (default: current directory)")
+  .action(usageCmd);
 
 program
   .command("mcp")

--- a/src/commands/query-cmds.ts
+++ b/src/commands/query-cmds.ts
@@ -4,9 +4,22 @@
 // `cx search` / `cx sql` / `cx status` - the query commands.
 
 import { openIndex, NoIndexError } from "../core/context.js";
+import { indexDir, resolveRoot } from "../core/config.js";
 import { createEmbedder, embedderInfo } from "../core/embedder.js";
 import { search, runSql, jsonify } from "../core/searcher.js";
-import { bold, dim, cyan, yellow, table, fmtAge, fmtCount, fmtMs } from "../core/output.js";
+import {
+  receiptEnabled,
+  searchEntry,
+  sqlEntry,
+  formatReceipt,
+  recordUsage,
+  readUsage,
+  clearUsage,
+  fmtTokens,
+  recordHookEvent,
+  currentSessionStats,
+} from "../core/usage.js";
+import { bold, dim, cyan, yellow, green, table, fmtAge, fmtCount, fmtMs } from "../core/output.js";
 
 function die(err: unknown): never {
   const msg = err instanceof NoIndexError ? err.message : `error: ${(err as Error).message}`;
@@ -24,6 +37,11 @@ export async function searchCmd(query: string, opts: SearchCmdOptions): Promise<
   try {
     const handle = openIndex(opts.path);
     const result = await search(handle, createEmbedder(), query, Number(opts.k));
+    if (receiptEnabled()) {
+      const entry = searchEntry(result, handle.root);
+      recordUsage(handle.dir, entry);
+      console.error(dim(formatReceipt(entry)));
+    }
     if (opts.json) {
       console.log(jsonify(result, true));
       return;
@@ -58,12 +76,16 @@ export async function sqlCmd(statement: string, opts: SqlCmdOptions): Promise<vo
       embeds[pair.slice(0, eq)] = pair.slice(eq + 1);
     }
     const rows = await runSql(handle, createEmbedder(), statement, embeds);
+    if (receiptEnabled()) {
+      const entry = sqlEntry(statement, rows);
+      recordUsage(handle.dir, entry);
+      console.error(dim(formatReceipt(entry)));
+    }
     if (opts.json) {
       console.log(jsonify(rows, true));
       return;
     }
     console.log(table(rows));
-    console.error(dim(`${rows.length} row${rows.length === 1 ? "" : "s"}`));
   } catch (err) {
     die(err);
   }
@@ -115,4 +137,103 @@ export function statusCmd(opts: StatusCmdOptions): void {
     .join(" · ");
   if (langs) console.log(`  languages  ${langs}`);
   console.log(dim(`  embedder   ${embedderInfo()}`));
+}
+
+export interface UsageCmdOptions {
+  json?: boolean;
+  /** How many of the most recent queries to list (default 20). */
+  n?: string;
+  all?: boolean;
+  clear?: boolean;
+  /** Consume a Claude Code hook event on stdin instead of printing a report. */
+  hook?: boolean;
+  path?: string;
+}
+
+const truncate = (s: string, n: number): string => (s.length > n ? s.slice(0, n - 3) + "..." : s);
+
+/** `cx usage` - the local ledger of what queries went through the index and a
+ * compact summary of what each returned. Read straight off `.infino/usage.jsonl`,
+ * so it's deterministic and needs no running server or model. */
+export async function usageCmd(opts: UsageCmdOptions): Promise<void> {
+  // Hook mode: invoked by Claude Code hooks (UserPromptSubmit / PostToolUse)
+  // with the event JSON on stdin. Update the local prompt/invocation counters
+  // and print nothing - hook stdout on UserPromptSubmit would be injected into
+  // the prompt, and a hook must never fail the session.
+  if (opts.hook) {
+    try {
+      const payload = JSON.parse(await readStdin());
+      const cwd = typeof payload.cwd === "string" ? payload.cwd : undefined;
+      recordHookEvent(indexDir(resolveRoot(cwd)), payload);
+    } catch {
+      // telemetry is best-effort
+    }
+    return;
+  }
+
+  const root = resolveRoot(opts.path);
+  const dir = indexDir(root);
+
+  if (opts.clear) {
+    clearUsage(dir);
+    console.log("usage log cleared");
+    return;
+  }
+
+  const entries = readUsage(dir);
+  const session = currentSessionStats(dir);
+  if (opts.json) {
+    console.log(jsonify({ queries: entries, session }, true));
+    return;
+  }
+  if (entries.length === 0 && (!session || session.prompts === 0)) {
+    console.error(yellow("no usage recorded yet - run `cx search`/`cx sql` here, or query via the MCP server"));
+    return;
+  }
+
+  const totalReturned = entries.reduce((n, e) => n + e.returnedTokens, 0);
+  console.log(`${bold("code-context usage")} - ${root}`);
+  if (entries.length) {
+    console.log(dim(`  ${fmtCount(entries.length)} queries | ~${fmtTokens(totalReturned)} tokens returned | since ${fmtAge(entries[0].ts)}`));
+  }
+  // The prompts-vs-invocations ratio comes from the Claude Code hooks (see
+  // `cx hook`); it's only here when those hooks are wired up.
+  if (session && session.prompts > 0) {
+    const used = Math.min(session.promptsWithCx, session.prompts);
+    const calls = `${session.cxCalls} call${session.cxCalls === 1 ? "" : "s"}`;
+    console.log(dim(`  this session: code-context used in ${used} of ${session.prompts} prompts (${calls})`));
+  }
+  console.log("");
+
+  const limit = opts.all ? entries.length : Math.max(1, Number(opts.n ?? 20));
+  for (const e of entries.slice(-limit)) {
+    const clock = new Date(e.ts).toLocaleTimeString("en-US", { hour12: false });
+    const tool = e.tool.padEnd(6);
+    const q = cyan(`"${truncate(e.query, 52)}"`);
+    if (e.tool === "search") {
+      const hits = e.hits ?? [];
+      const files = new Set(hits.map((h) => h.path)).size;
+      console.log(
+        `${dim(clock)}  ${bold(tool)}  ${q}  ${dim(`-> ${hits.length} hits / ${files} files | ~${fmtTokens(e.returnedTokens)} tok | ${e.ranking ?? "?"}`)}`,
+      );
+      const locs = hits.slice(0, 5).map((h) => `${h.path}:${h.startLine}-${h.endLine}`);
+      if (locs.length) console.log(green(`            ${locs.join("  ")}${hits.length > 5 ? dim(`  (+${hits.length - 5} more)`) : ""}`));
+    } else {
+      console.log(
+        `${dim(clock)}  ${bold(tool)}  ${q}  ${dim(`-> ${e.rows ?? 0} rows | ~${fmtTokens(e.returnedTokens)} tok`)}`,
+      );
+    }
+  }
+}
+
+/** Read all of stdin (the Claude Code hook payload); empty when run by hand. */
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) return resolve(""); // invoked by hand, no payload
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(""));
+  });
 }

--- a/src/core/usage.ts
+++ b/src/core/usage.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Usage accounting: the per-call receipt and the on-disk ledger behind
+// `cx usage`. Both are built from the same structured entry so the whole-file
+// stat runs once. Everything is local and factual - tokens are a `~` chars/4
+// estimate (we can't run the agent's tokenizer), and nothing leaves the
+// machine: the ledger is a plain JSONL file inside the repo's index dir.
+
+import { appendFileSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { jsonify, type SearchResult } from "./searcher.js";
+
+/** Rough tokens-per-char - the standard heuristic for English + code. Kept
+ * deliberately simple: usage reports `~` figures, not a billed count. */
+const CHARS_PER_TOKEN = 4;
+
+export const estTokens = (s: string): number => Math.ceil(s.length / CHARS_PER_TOKEN);
+
+/** Running totals for one server session (the long-lived `cx mcp` process). */
+export interface SessionUsage {
+  queries: number;
+  returnedTokens: number;
+}
+
+export const newSession = (): SessionUsage => ({ queries: 0, returnedTokens: 0 });
+
+/** Whether usage accounting is on. Default on - off only when CX_NO_RECEIPT is
+ * set. One switch governs both the inline receipt and the ledger, shared by the
+ * MCP server and the CLI. */
+export const receiptEnabled = (): boolean =>
+  !["1", "true", "yes"].includes((process.env.CX_NO_RECEIPT ?? "").toLowerCase());
+
+// --- the structured entry ---------------------------------------------------
+
+/** One recorded query: what was asked and a compact summary of what came back.
+ * Deliberately does not store chunk content - the ledger points at path:line,
+ * it doesn't duplicate the repo. */
+export interface UsageEntry {
+  ts: string;
+  tool: "search" | "sql";
+  query: string;
+  returnedTokens: number;
+  /** search only: whole-file size of the distinct files the hits came from. */
+  wholeFileTokens?: number | null;
+  ranking?: "hybrid" | "keyword";
+  /** search only: the response, as the regions you'd jump to. */
+  hits?: Array<{ path: string; startLine: number; endLine: number }>;
+  /** sql only. */
+  rows?: number;
+  /** sql only: a truncated preview of the returned rows (the answer itself). */
+  rowsPreview?: string;
+}
+
+/** Best-effort sum of the on-disk size (as tokens) of the distinct files the
+ * hits came from - the "what reading them whole would cost" counterfactual.
+ * Conservative: a file we can't stat is skipped, never guessed, so the figure
+ * only ever understates the whole-file cost. null when nothing was stattable. */
+function wholeFileTokens(paths: string[], root: string): number | null {
+  let total = 0;
+  let counted = 0;
+  for (const p of paths) {
+    try {
+      total += Math.ceil(statSync(resolve(root, p)).size / CHARS_PER_TOKEN);
+      counted++;
+    } catch {
+      // unreadable/moved since indexing - drop it rather than mislead
+    }
+  }
+  return counted > 0 ? total : null;
+}
+
+export function searchEntry(result: SearchResult, root: string): UsageEntry {
+  const hits = result.hits.map((h) => ({ path: h.path, startLine: h.startLine, endLine: h.endLine }));
+  const files = [...new Set(hits.map((h) => h.path))];
+  return {
+    ts: new Date().toISOString(),
+    tool: "search",
+    query: result.query,
+    returnedTokens: result.hits.reduce((n, h) => n + estTokens(h.content), 0),
+    wholeFileTokens: wholeFileTokens(files, root),
+    ranking: result.ranking,
+    hits,
+  };
+}
+
+const ROWS_PREVIEW_CAP = 2000;
+
+export function sqlEntry(query: string, rows: Array<Record<string, unknown>>): UsageEntry {
+  const serialized = jsonify(rows);
+  return {
+    ts: new Date().toISOString(),
+    tool: "sql",
+    query,
+    returnedTokens: estTokens(serialized),
+    rows: rows.length,
+    rowsPreview: serialized.length > ROWS_PREVIEW_CAP ? serialized.slice(0, ROWS_PREVIEW_CAP) + "..." : serialized,
+  };
+}
+
+// --- the one-line receipt ----------------------------------------------------
+
+/** 1203 -> "1.2k", 300 -> "300". */
+export function fmtTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+const plural = (n: number, one: string, many: string): string => `${n} ${n === 1 ? one : many}`;
+
+/** The terse receipt line for an entry, ASCII-only so it can't mojibake.
+ * Mutates and appends the running total when a session is supplied. */
+export function formatReceipt(entry: UsageEntry, session?: SessionUsage): string {
+  const parts: string[] = [];
+  if (entry.tool === "search") {
+    const hits = entry.hits ?? [];
+    const files = new Set(hits.map((h) => h.path)).size;
+    // Just what was returned - no "vs whole file" counterfactual here: it's an
+    // estimate of a road not taken, not a measured saving, so we don't assert
+    // it after every response. The raw wholeFileTokens still lives in the entry
+    // for anyone who wants to reason about it from the ledger.
+    parts.push(`returned ~${fmtTokens(entry.returnedTokens)} tokens | ${plural(hits.length, "chunk", "chunks")} / ${plural(files, "file", "files")}`);
+  } else {
+    parts.push(`returned ~${fmtTokens(entry.returnedTokens)} tokens | ${plural(entry.rows ?? 0, "row", "rows")}`);
+  }
+  if (session) {
+    session.queries++;
+    session.returnedTokens += entry.returnedTokens;
+    parts.push(`invoked ${session.queries}x this session (~${fmtTokens(session.returnedTokens)} tokens total)`);
+  }
+  return parts.join(" | ");
+}
+
+// --- the on-disk ledger ------------------------------------------------------
+
+/** The usage log lives beside the manifest in the index dir; the engine ignores
+ * foreign files in its catalog root, and `.infino/` is already gitignored. */
+export const USAGE_LOG = "usage.jsonl";
+export const usageLogPath = (indexDir: string): string => join(indexDir, USAGE_LOG);
+
+/** Append one entry. Best-effort: accounting must never break a query, so a
+ * write failure (read-only dir, race) is swallowed. */
+export function recordUsage(indexDir: string, entry: UsageEntry): void {
+  try {
+    appendFileSync(usageLogPath(indexDir), jsonify(entry) + "\n");
+  } catch {
+    // logging is a convenience, not a guarantee
+  }
+}
+
+/** Read the ledger back, oldest first. Tolerant of a partially-written last
+ * line and of hand-edits - unparseable lines are skipped. */
+export function readUsage(indexDir: string): UsageEntry[] {
+  let raw: string;
+  try {
+    raw = readFileSync(usageLogPath(indexDir), "utf8");
+  } catch {
+    return [];
+  }
+  const out: UsageEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as UsageEntry);
+    } catch {
+      // skip a torn or edited line
+    }
+  }
+  return out;
+}
+
+export function clearUsage(indexDir: string): void {
+  rmSync(usageLogPath(indexDir), { force: true });
+}
+
+// --- prompt telemetry (local, via Claude Code hooks) ------------------------
+//
+// The receipt is server-side and can only count its own invocations - it can't
+// see how many prompts you ran or turns where it wasn't called. That "used in
+// K of N prompts" ratio lives in the client, so we collect it from Claude Code
+// hooks: UserPromptSubmit ticks the prompt count, PostToolUse on a code-context
+// tool ticks the invocation count (and marks the prompt as one that used it).
+// Everything stays in a local file; nothing is sent anywhere.
+
+export const PROMPT_STATS = "prompt-stats.json";
+export const promptStatsPath = (indexDir: string): string => join(indexDir, PROMPT_STATS);
+
+/** Per-session prompt/invocation counters, keyed by Claude Code session id. */
+export interface PromptStats {
+  sessionId: string;
+  startedAt: string;
+  lastAt: string;
+  /** UserPromptSubmit events - how many prompts the user ran. */
+  prompts: number;
+  /** code-context tool invocations across the session. */
+  cxCalls: number;
+  /** prompts in which code-context was used at least once. */
+  promptsWithCx: number;
+  /** transient: has the current prompt already used code-context. */
+  curPromptUsedCx: boolean;
+}
+
+/** The shape Claude Code delivers to a hook command on stdin (subset we use). */
+export interface HookPayload {
+  hook_event_name?: string;
+  session_id?: string;
+  tool_name?: string;
+  cwd?: string;
+}
+
+/** A tool name is code-context's when it's one of our MCP tools - matches the
+ * default server and any renamed variant (e.g. code-context-local). */
+const isCodeContextTool = (name?: string): boolean => !!name && /^mcp__code[-_]?context/i.test(name);
+
+const MAX_SESSIONS = 25;
+
+function loadPromptStats(indexDir: string): Record<string, PromptStats> {
+  try {
+    return JSON.parse(readFileSync(promptStatsPath(indexDir), "utf8")) as Record<string, PromptStats>;
+  } catch {
+    return {};
+  }
+}
+
+function savePromptStats(indexDir: string, all: Record<string, PromptStats>): void {
+  // Keep the file bounded: newest MAX_SESSIONS sessions by last activity.
+  const kept = Object.values(all)
+    .sort((a, b) => (a.lastAt < b.lastAt ? 1 : -1))
+    .slice(0, MAX_SESSIONS);
+  const pruned: Record<string, PromptStats> = {};
+  for (const s of kept) pruned[s.sessionId] = s;
+  try {
+    writeFileSync(promptStatsPath(indexDir), JSON.stringify(pruned, null, 2));
+  } catch {
+    // telemetry is a convenience, never fail the hook
+  }
+}
+
+/** Fold one Claude Code hook event into the local counters. Best-effort. */
+export function recordHookEvent(indexDir: string, payload: HookPayload): void {
+  const event = payload.hook_event_name ?? "";
+  const tracked = event === "UserPromptSubmit" || (event === "PostToolUse" && isCodeContextTool(payload.tool_name));
+  if (!tracked) return;
+
+  const sid = payload.session_id ?? "unknown";
+  const now = new Date().toISOString();
+  const all = loadPromptStats(indexDir);
+  const s: PromptStats =
+    all[sid] ?? { sessionId: sid, startedAt: now, lastAt: now, prompts: 0, cxCalls: 0, promptsWithCx: 0, curPromptUsedCx: false };
+
+  if (event === "UserPromptSubmit") {
+    s.prompts++;
+    s.curPromptUsedCx = false;
+  } else {
+    s.cxCalls++;
+    if (!s.curPromptUsedCx && s.prompts > 0) {
+      s.promptsWithCx++;
+      s.curPromptUsedCx = true;
+    }
+  }
+  s.lastAt = now;
+  all[sid] = s;
+  savePromptStats(indexDir, all);
+}
+
+/** The most recently active session's counters, or null if none recorded. */
+export function currentSessionStats(indexDir: string): PromptStats | null {
+  const all = Object.values(loadPromptStats(indexDir));
+  if (all.length === 0) return null;
+  return all.sort((a, b) => (a.lastAt < b.lastAt ? 1 : -1))[0];
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,7 @@ import { indexDir, resolveRoot, TABLE, DEFAULT_CAPS, DEFAULT_SEARCH_K } from "..
 import { readManifest, type Manifest } from "../core/manifest.js";
 import type { IndexHandle } from "../core/context.js";
 import { search, runSql, jsonify, partialIndex } from "../core/searcher.js";
+import { newSession, receiptEnabled, searchEntry, sqlEntry, formatReceipt, recordUsage } from "../core/usage.js";
 import { indexRepoStaged, syncRepo, type SyncOutcome, type IndexStats } from "../core/indexer.js";
 import { createEmbedder, embedderInfo, type Embedder } from "../core/embedder.js";
 import { RepoRegistry, type RepoCtx } from "./repos.js";
@@ -61,6 +62,13 @@ export async function serveMcp(rootPath?: string): Promise<void> {
   // on the same call (staged: keyword search live in seconds). Off restores the
   // strict "index it first" error.
   const autoIndexEnabled = !["0", "false", "no"].includes((process.env.CX_AUTO_INDEX ?? "").toLowerCase());
+
+  // A terse, local, factual receipt appended to each query result (tokens
+  // returned, files touched, whole-file size it stood in for, session running
+  // total). Default on - the trust signal only works when it's there; silence
+  // it with CX_NO_RECEIPT. One accumulator per session (this long-lived process).
+  const receiptOn = receiptEnabled();
+  const session = newSession();
 
   /** Run an index mutation on a repo exclusively; null if one is in flight. */
   const exclusive = <T,>(ctx: RepoCtx, fn: () => Promise<T>): Promise<T> | null => {
@@ -168,7 +176,10 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         "Every tool takes an optional 'path' (an absolute repo root): omit it for the default repo, " +
         "or set it to target a specific one when you're working across more than one repo in a session.\n" +
         "If a result carries a 'partial' marker, the repo exceeded the index's file cap and some files " +
-        "were left out: treat a missing match as possibly-unindexed, not proof it's absent.",
+        "were left out: treat a missing match as possibly-unindexed, not proof it's absent.\n" +
+        "Each result carries a 'usage' receipt (tokens returned, chunks/files, and a session running " +
+        "total) - computed locally, nothing leaves the machine. Surface it to the user so they can see " +
+        "how much context the ranked results put into the conversation.",
     },
   );
 
@@ -191,7 +202,9 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         "query and search again - the index has already ranked the relevant regions. Read a file only " +
         "for a hit marked truncated (its cited start-end range via offset/limit), or when results " +
         "genuinely don't cover the question. (Until the index's vector stage finishes, results are " +
-        "keyword-ranked and say so.)",
+        "keyword-ranked and say so.) The result includes a 'usage' field - a one-line receipt " +
+        "(tokens returned, chunks/files, session total). After you " +
+        "answer, end your reply by showing that 'usage' line to the user verbatim.",
       inputSchema: {
         query: z.string().describe("What you're looking for - terms, a phrase, or a description."),
         k: z.number().int().positive().max(50).default(DEFAULT_SEARCH_K).describe("Maximum hits."),
@@ -223,10 +236,17 @@ export async function serveMcp(rootPath?: string): Promise<void> {
       try {
         const t0 = performance.now();
         const result = await search(handle, getEmbedder(), query, k);
+        let usage: string | undefined;
+        if (receiptOn) {
+          const entry = searchEntry(result, ctx.root);
+          recordUsage(ctx.dir, entry);
+          usage = formatReceipt(entry, session);
+        }
         return ok({
           ...result,
           ...(autoIndexed ? { auto_indexed: autoIndexNote(autoIndexed) } : {}),
           took_ms: Math.round((performance.now() - t0) * 1000) / 1000,
+          ...(usage ? { usage } : {}),
         });
       } catch (err) {
         return fail(`search failed: ${(err as Error).message}`);
@@ -250,7 +270,9 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         'X": SELECT path, SUM(end_line - start_line + 1) AS lines FROM ' +
         `bm25_search('${TABLE}','content','<terms>', 300) GROUP BY path ORDER BY lines DESC LIMIT 15. ` +
         "Build queries on bm25_search/hybrid_search so results are ranked by relevance to the topic, " +
-        "not on a raw scan of the whole table. Read-only, single statement.",
+        "not on a raw scan of the whole table. Read-only, single statement. The result includes a " +
+        "'usage' field - a one-line receipt (tokens returned, rows, session total). After " +
+        "you answer, end your reply by showing that 'usage' line to the user verbatim.",
       inputSchema: {
         query: z
           .string()
@@ -288,11 +310,18 @@ export async function serveMcp(rootPath?: string): Promise<void> {
         const t0 = performance.now();
         const rows = await runSql(handle, getEmbedder(), query, embed as Record<string, string> | undefined);
         const partial = partialIndex(handle.manifest);
+        let usage: string | undefined;
+        if (receiptOn) {
+          const entry = sqlEntry(query, rows);
+          recordUsage(ctx.dir, entry);
+          usage = formatReceipt(entry, session);
+        }
         return ok({
           rows,
           ...(partial ? { partial } : {}),
           ...(autoIndexed ? { auto_indexed: autoIndexNote(autoIndexed) } : {}),
           took_ms: Math.round((performance.now() - t0) * 1000) / 1000,
+          ...(usage ? { usage } : {}),
         });
       } catch (err) {
         return fail(`sql failed: ${(err as Error).message}`);

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  estTokens,
+  newSession,
+  searchEntry,
+  sqlEntry,
+  formatReceipt,
+  recordUsage,
+  readUsage,
+  clearUsage,
+  usageLogPath,
+  recordHookEvent,
+  currentSessionStats,
+} from "../src/core/usage.js";
+import type { SearchResult, SearchHit } from "../src/core/searcher.js";
+
+const hit = (path: string, content: string): SearchHit => ({
+  path,
+  startLine: 1,
+  endLine: 10,
+  lang: "ts",
+  score: 1,
+  content,
+});
+
+const result = (hits: SearchHit[]): SearchResult => ({ query: "q", ranking: "keyword", hits });
+
+describe("estTokens", () => {
+  it("estimates ~chars/4", () => {
+    expect(estTokens("")).toBe(0);
+    expect(estTokens("abcd")).toBe(1);
+    expect(estTokens("abcde")).toBe(2);
+  });
+});
+
+describe("search receipt", () => {
+  let root: string;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "cx-usage-"));
+    writeFileSync(join(root, "a.ts"), "x".repeat(4000)); // ~1k tokens on disk
+    writeFileSync(join(root, "b.ts"), "y".repeat(4000));
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it("reports tokens returned and chunks/files, with no trailing markers", () => {
+    const line = formatReceipt(searchEntry(result([hit("a.ts", "z".repeat(400)), hit("a.ts", "z".repeat(400))]), root));
+    expect(line).toBe("returned ~200 tokens | 2 chunks / 1 file");
+  });
+
+  it("does not assert a whole-file counterfactual in the receipt", () => {
+    // The estimate still lives on the entry (for the ledger), but the receipt
+    // shown after every response makes no "vs reading them whole" claim.
+    const entry = searchEntry(result([hit("a.ts", "z".repeat(40)), hit("b.ts", "z".repeat(40))]), root);
+    expect(entry.wholeFileTokens).toBeGreaterThan(0);
+    const line = formatReceipt(entry);
+    expect(line).not.toMatch(/whole/);
+    expect(line).not.toMatch(/\bvs\b/);
+  });
+
+  it("accumulates the session invocation count and token total across calls", () => {
+    const session = newSession();
+    formatReceipt(searchEntry(result([hit("a.ts", "z".repeat(400))]), root), session); // +100
+    const line = formatReceipt(searchEntry(result([hit("a.ts", "z".repeat(400))]), root), session); // +100
+    expect(session.queries).toBe(2);
+    expect(session.returnedTokens).toBe(200);
+    expect(line).toMatch(/invoked 2x this session \(~200 tokens total\)/);
+  });
+
+  it("counts the first call as invoked 1x", () => {
+    const session = newSession();
+    const line = formatReceipt(searchEntry(result([hit("a.ts", "z".repeat(40))]), "/nope"), session);
+    expect(line).toMatch(/invoked 1x this session/);
+  });
+});
+
+describe("sql receipt", () => {
+  it("reports row count and token estimate of the rows", () => {
+    const line = formatReceipt(sqlEntry("SELECT 1", [{ path: "a.ts", lines: 12 }, { path: "b.ts", lines: 8 }]));
+    expect(line).toMatch(/^returned ~\d+ tokens \| 2 rows$/);
+  });
+
+  it("accumulates into the session and has no whole-file clause", () => {
+    const session = newSession();
+    const line = formatReceipt(sqlEntry("SELECT 1", [{ a: 1 }]), session);
+    expect(session.queries).toBe(1);
+    expect(line).not.toMatch(/to read those files whole/);
+    expect(line).toMatch(/invoked 1x this session/);
+  });
+});
+
+describe("the ledger", () => {
+  let dir: string;
+  beforeAll(() => (dir = mkdtempSync(join(tmpdir(), "cx-ledger-"))));
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("round-trips entries oldest-first and captures the response summary", () => {
+    recordUsage(dir, searchEntry({ query: "auth", ranking: "hybrid", hits: [hit("a.ts", "zzzz")] }, dir));
+    recordUsage(dir, sqlEntry("SELECT count(*)", [{ n: 3 }]));
+    const entries = readUsage(dir);
+    expect(entries.map((e) => e.tool)).toEqual(["search", "sql"]);
+    expect(entries[0].query).toBe("auth");
+    expect(entries[0].hits?.[0]).toMatchObject({ path: "a.ts", startLine: 1, endLine: 10 });
+    expect(entries[1].rows).toBe(1);
+  });
+
+  it("skips torn / hand-edited lines instead of throwing", () => {
+    writeFileSync(usageLogPath(dir), '{"tool":"search"}\nnot json\n', { flag: "a" });
+    expect(() => readUsage(dir)).not.toThrow();
+    expect(readUsage(dir).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("clears the log", () => {
+    clearUsage(dir);
+    expect(existsSync(usageLogPath(dir))).toBe(false);
+    expect(readUsage(dir)).toEqual([]);
+  });
+});
+
+describe("prompt telemetry (hooks)", () => {
+  let dir: string;
+  beforeEach(() => (dir = mkdtempSync(join(tmpdir(), "cx-hooks-"))));
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const submit = (sid: string) => recordHookEvent(dir, { hook_event_name: "UserPromptSubmit", session_id: sid });
+  const cxCall = (sid: string) => recordHookEvent(dir, { hook_event_name: "PostToolUse", session_id: sid, tool_name: "mcp__code-context__search" });
+  const otherCall = (sid: string) => recordHookEvent(dir, { hook_event_name: "PostToolUse", session_id: sid, tool_name: "Grep" });
+
+  it("counts prompts, cx calls, and prompts-that-used-cx (once per prompt)", () => {
+    submit("s1");
+    cxCall("s1");
+    cxCall("s1"); // 2 calls in prompt 1, but the prompt counts once
+    submit("s1"); // prompt 2, no cx
+    submit("s1"); // prompt 3
+    cxCall("s1");
+    const s = currentSessionStats(dir);
+    expect(s?.prompts).toBe(3);
+    expect(s?.cxCalls).toBe(3);
+    expect(s?.promptsWithCx).toBe(2);
+  });
+
+  it("ignores tools that aren't code-context", () => {
+    submit("s1");
+    otherCall("s1");
+    const s = currentSessionStats(dir);
+    expect(s?.cxCalls).toBe(0);
+    expect(s?.promptsWithCx).toBe(0);
+  });
+
+  it("counts a matching variant like code-context-local", () => {
+    recordHookEvent(dir, { hook_event_name: "UserPromptSubmit", session_id: "s1" });
+    recordHookEvent(dir, { hook_event_name: "PostToolUse", session_id: "s1", tool_name: "mcp__code-context-local__sql" });
+    expect(currentSessionStats(dir)?.cxCalls).toBe(1);
+  });
+
+  it("does not let promptsWithCx exceed prompts when a call precedes any prompt", () => {
+    cxCall("s1"); // no UserPromptSubmit yet
+    const s = currentSessionStats(dir);
+    expect(s?.cxCalls).toBe(1);
+    expect(s?.prompts).toBe(0);
+    expect(s?.promptsWithCx).toBe(0);
+  });
+
+  it("returns null when nothing is recorded", () => {
+    expect(currentSessionStats(dir)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

- **Per-call usage receipt** on every `search`/`sql` result (CLI and MCP): tokens returned, chunks/files, and a per-session invocation count, e.g. `returned ~1.6k tokens | 3 chunks / 3 files | invoked 4x this session (~8.0k tokens total)`. Opt out with `CX_NO_RECEIPT`.
- **`cx usage`** reads a local, append-only ledger (`.infino/usage.jsonl`) of the queries run and a compact summary of what each returned (paths + line ranges for search, row count for sql). Deterministic and model-independent, no running server needed to read it back.
- **Prompt-vs-invocation telemetry (opt-in):** wired via `UserPromptSubmit`/`PostToolUse` hooks that call `cx usage --hook`, the report also shows how many of your prompts used code-context (`code-context used in 2 of 3 prompts (2 calls)`). Stays local; nothing is sent anywhere.

## Notes

- **No new MCP tools** - kept the deliberate three (search/sql/reindex). The receipt rides on existing results; the hook folds into `cx usage --hook`, mirroring the existing `cx status --hook`.
- All figures are `~` estimates (chars/4), computed in-process. No fabricated savings claims.
- No version bump in this PR.
- Adds a `usage` test suite; full suite is green (84 tests).
