### PR TITLE
Add Claude Code plugin + alwaysLoad install docs (0.1.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "infino-ai",
+  "owner": { "name": "Infino AI" },
+  "metadata": {
+    "description": "Infino AI's marketplace of Claude Code plugins. Currently code-context (local codebase search for coding agents), with more to come."
+  },
+  "plugins": [
+    {
+      "name": "code-context",
+      "source": "./",
+      "description": "Local hybrid keyword + semantic search and SQL over your codebase, for coding agents."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "code-context",
+  "description": "Local hybrid keyword + semantic search and SQL over your codebase, for coding agents.",
+  "version": "0.1.3",
+  "author": { "name": "Infino AI" },
+  "homepage": "https://github.com/infino-ai/code-context"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "code-context": {
+      "command": "npx",
+      "args": ["-y", "@infino-ai/code-context", "mcp"],
+      "alwaysLoad": true
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -56,8 +56,16 @@ the same engine handles logs, docs, and agent memory.
 Add it to Claude Code with one command, nothing to install:
 
 ```
-claude mcp add code-context -- npx -y @infino-ai/code-context mcp
+claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'
 ```
+
+The `alwaysLoad` flag keeps code-context's three tools in the agent's view. In
+a setup with many MCP servers, clients defer tool definitions behind a
+tool-search step, and the agent can miss the index and fall back to plain file
+search; `alwaysLoad` pins this small tool set so it reaches for the index
+directly. Prefer the shorter form and don't need that? `claude mcp add
+code-context -- npx -y @infino-ai/code-context mcp` works too (tools stay
+deferred). There's also a [plugin](#setup-for-agents) that bakes this in.
 
 Then just ask a question about the code. The first `search` or `sql` on an
 unindexed repo builds the index inline and answers on the same call: keyword
@@ -155,7 +163,33 @@ agent.
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude mcp add code-context -- npx -y @infino-ai/code-context mcp
+claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'
+```
+
+`alwaysLoad: true` pins code-context's tools into context so the agent reaches
+for the index directly. In sessions with many MCP servers Claude Code defers
+tool definitions behind a tool-search step; without `alwaysLoad` the agent can
+miss code-context and fall back to grep/read. It's a small, always-loaded set
+(three tools), so this is the recommended setup. Omit it (or use the shorter
+`claude mcp add code-context -- npx -y @infino-ai/code-context mcp`) if you'd
+rather leave the tools deferred.
+
+**Or install as a plugin** for the same effect with `alwaysLoad` already set,
+nothing to paste into a config:
+
+```
+/plugin marketplace add infino-ai/code-context
+/plugin install code-context@infino-ai
+```
+
+Use *either* the plugin or the `add-json` command, not both. They register the
+same `code-context` server, so running both just collides.
+
+**For a team,** commit a project-scoped `.mcp.json` at the repo root so
+everyone gets it (after the one-time project-server approval):
+
+```json
+{ "mcpServers": { "code-context": { "command": "npx", "args": ["-y", "@infino-ai/code-context", "mcp"], "alwaysLoad": true } } }
 ```
 
 </details>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -94,10 +94,11 @@ indexable.
 
 ### Which MCP clients work?
 
-Any MCP client, over stdio. In Claude Code:
-`claude mcp add code-context -- npx -y @infino-ai/code-context mcp`. Codex,
-Gemini CLI, Windsurf, Cline, and others use the standard
-stdio config in the README.
+Any MCP client, over stdio. In Claude Code (recommended form, since `alwaysLoad`
+keeps the tools in view when many MCP servers are configured):
+`claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'`
+(or install the plugin; see the README). Codex, Gemini CLI, Windsurf, Cline,
+and others use the standard stdio config in the README.
 
 ### What is it built on?
 

--- a/llms.txt
+++ b/llms.txt
@@ -22,8 +22,10 @@ logs, docs, and agent memory.
 
 - Install: `npm install -g @infino-ai/code-context` (bins `code-context`
   and `cx`), then `cx index` in a repo.
-- Zero-install for Claude Code:
-  `claude mcp add code-context -- npx -y @infino-ai/code-context mcp`.
+- Zero-install for Claude Code (recommended; `alwaysLoad` keeps the tools in
+  view when many MCP servers are configured):
+  `claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'`.
+  A Claude Code plugin (`/plugin marketplace add infino-ai/code-context`) bakes the same config in.
 - MCP tools (stdio): `search` (exact terms AND meaning, one ranked pass,
   hits carry chunk content with path:line ranges), `sql` (read-only
   SELECT/WITH over `chunks(path, start_line, end_line, lang, content)`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infino-ai/code-context",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@infino-ai/code-context",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/code-context",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "mcpName": "io.github.infino-ai/code-context",
   "description": "Local code search for AI coding agents: a CLI and MCP server with hybrid keyword + semantic search and SQL relevance-ranked aggregation over an index that lives in plain files. No accounts, no keys, no server.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Ships code-context as an installable Claude Code plugin so its tools load eagerly (`alwaysLoad`) without users hand-editing config.

## Changes
- **`.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`** — the repo doubles as its own plugin marketplace. Install with `/plugin marketplace add infino-ai/code-context` then `/plugin install code-context@infino-ai`.
- **`.mcp.json`** — the plugin's MCP server config with `alwaysLoad: true`. Note: the config must live in a bundled `.mcp.json`; an inline `mcpServers` block inside `plugin.json` is not picked up by the plugin loader.
- **README / faq / llms.txt** — install docs now lead with the `alwaysLoad`-enabled `add-json` command and mention the plugin, with a note to use one or the other (both register the same `code-context` server and would collide).
- **Version bumped to 0.1.3** (package.json + lockfile).

## Why alwaysLoad
In sessions with many MCP servers, tool definitions are deferred behind tool-search and the agent tends to fall back to grep/read instead of the index. `alwaysLoad` keeps this small (three-tool) set in view so the agent reaches for it directly. It only matters in tool-heavy setups; elsewhere it is a no-op.