### PR TITLE
chunking: bash/css/powershell grammars + AST-context embeddings

### DIFF
--- a/src/core/chunker.ts
+++ b/src/core/chunker.ts
@@ -16,7 +16,43 @@ export interface Chunk {
   startLine: number;
   endLine: number;
   lang: string;
+  /** Raw file bytes for this line range - what results return, cited as
+   * path:start-end. Never enriched, so the citation stays exact. */
   content: string;
+  /** Definition name(s) starting in this chunk (e.g. "parseConfig"); for
+   * markdown, the heading text. Absent for fixed-window / unparsed chunks. */
+  symbol?: string;
+  /** Coarse kind of the primary definition: function/class/method/... */
+  kind?: string;
+  /** Enclosing breadcrumb of the primary definition (e.g. "ConfigLoader"). */
+  scope?: string;
+}
+
+/** A definition site found in the AST: where it starts and how to name it. */
+interface DefSite {
+  row: number; // 0-based
+  name: string;
+  kind: string;
+  scope: string;
+}
+
+/** The text we embed / index for a chunk: a compact, deterministic context
+ * header (path + breadcrumb + symbol) prepended to the raw content. The header
+ * is never returned - it only sharpens the vector, the way Anthropic's
+ * contextual retrieval does, but built from the AST instead of an LLM. */
+// CX_EMBED_RAW=1 embeds raw content only (no path/symbol header) - an eval lever
+// for A/B-ing enrichment, in the spirit of CX_EMBED_MODEL.
+const RAW_EMBED = ["1", "true", "yes"].includes((process.env.CX_EMBED_RAW ?? "").toLowerCase());
+
+/** The text we embed / index for a chunk: a compact, deterministic context
+ * header (path + breadcrumb + symbol) prepended to the raw content, which
+ * sharpens the vector - Anthropic-style contextual retrieval, built from the
+ * AST rather than an LLM. The header is never returned; results keep the raw
+ * content, so citations stay exact. */
+export function embedText(c: Chunk): string {
+  if (RAW_EMBED) return c.content;
+  const crumb = [c.scope, c.symbol].filter(Boolean).join(" › ");
+  return crumb ? `${c.path}\n${crumb}\n${c.content}` : `${c.path}\n${c.content}`;
 }
 
 // Window tuning: target is the preferred chunk size; a single syntactic unit
@@ -96,6 +132,7 @@ const TS_GRAMMAR: Record<string, string> = {
   ts: "typescript", tsx: "tsx", js: "javascript",
   py: "python", rs: "rust", go: "go", java: "java",
   c: "cpp", cpp: "cpp", rb: "ruby", cs: "c-sharp", php: "php",
+  sh: "bash", css: "css", ps1: "powershell",
 };
 
 // Node types whose start lines become chunk break points, per grammar.
@@ -133,6 +170,17 @@ const DEF_TYPES: Record<string, Set<string>> = {
     "function_definition", "method_declaration", "class_declaration",
     "interface_declaration", "trait_declaration",
   ]),
+  // Shell: break at function definitions (scripts are otherwise flat).
+  bash: new Set(["function_definition"]),
+  // CSS: break at each rule set and at-rule block; packSegments coalesces
+  // small rules into windows, so this doesn't over-fragment.
+  css: new Set([
+    "rule_set", "media_statement", "keyframes_statement",
+    "supports_statement", "at_rule", "import_statement",
+  ]),
+  // PowerShell: functions (nested under statement_list, found by the recursive
+  // collect); class_statement is harmless when the grammar lacks it.
+  powershell: new Set(["function_statement", "class_statement"]),
 };
 DEF_TYPES.tsx = DEF_TYPES.typescript;
 
@@ -150,9 +198,11 @@ type TSParser = {
 };
 type TSNode = {
   type: string;
+  text: string;
   startPosition: { row: number };
   endPosition: { row: number };
   namedChildren: TSNode[];
+  childForFieldName(name: string): TSNode | null;
 };
 
 let runtime: Promise<{ Parser: new () => TSParser; Language: { load(path: string): Promise<unknown> } }> | null = null;
@@ -196,9 +246,10 @@ function getLanguage(grammar: string): Promise<unknown | null> {
   return lang;
 }
 
-/** Break points (0-based rows) at definition starts, or undefined when the
- * language has no grammar or parsing fails. */
-async function syntacticBreaks(lang: string, content: string): Promise<number[] | undefined> {
+/** Definition sites (0-based start row + name/kind/scope), or undefined when
+ * the language has no grammar or parsing fails. The rows drive chunk break
+ * points; the names/scope enrich the embed text. */
+async function syntacticDefs(lang: string, content: string): Promise<DefSite[] | undefined> {
   const grammar = TS_GRAMMAR[lang];
   if (!grammar || content.length > PARSE_CAP_BYTES) return undefined;
   if (parseFailures >= MAX_PARSE_FAILURES) return undefined;
@@ -218,9 +269,9 @@ async function syntacticBreaks(lang: string, content: string): Promise<number[] 
     });
     if (!tree) return undefined;
     const defs = DEF_TYPES[grammar];
-    const rows = new Set<number>();
-    collect(tree.rootNode, defs, rows, 0);
-    return [...rows].sort((a, b) => a - b);
+    const sites: DefSite[] = [];
+    collectDefs(tree.rootNode, defs, [], sites, 0);
+    return sites.sort((a, b) => a.row - b.row);
   } catch {
     parseFailures++;
     parser = null; // a failed parser instance is not trusted again
@@ -231,12 +282,45 @@ async function syntacticBreaks(lang: string, content: string): Promise<number[] 
 // Depth cap keeps this to module/class/method level, not local closures.
 const MAX_DEPTH = 6;
 
-function collect(node: TSNode, defs: Set<string>, rows: Set<number>, depth: number): void {
+function collectDefs(node: TSNode, defs: Set<string>, scope: string[], sites: DefSite[], depth: number): void {
   if (depth > MAX_DEPTH) return;
   for (const child of node.namedChildren) {
-    if (defs.has(child.type)) rows.add(child.startPosition.row);
-    collect(child, defs, rows, depth + 1);
+    if (defs.has(child.type)) {
+      const name = nameOf(child);
+      sites.push({ row: child.startPosition.row, name, kind: kindOf(child.type), scope: scope.join(" › ") });
+      collectDefs(child, defs, name ? [...scope, name] : scope, sites, depth + 1);
+    } else {
+      collectDefs(child, defs, scope, sites, depth + 1);
+    }
   }
+}
+
+/** Best-effort definition name: the grammar's `name` field, else the first
+ * identifier-ish named child (covers declarator-wrapped names like C++). */
+function nameOf(node: TSNode): string {
+  const clip = (s: string) => s.split("\n")[0].trim().slice(0, 80);
+  const named = node.childForFieldName?.("name");
+  if (named?.text) return clip(named.text);
+  for (const c of node.namedChildren) {
+    if (/identifier|name|selectors/.test(c.type)) return clip(c.text);
+  }
+  return "";
+}
+
+/** Coarse kind from a grammar node type - only used to flavour the embed
+ * header, so a loose match is fine. */
+function kindOf(type: string): string {
+  if (/class/.test(type)) return "class";
+  if (/interface/.test(type)) return "interface";
+  if (/struct/.test(type)) return "struct";
+  if (/enum/.test(type)) return "enum";
+  if (/trait/.test(type)) return "trait";
+  if (/impl/.test(type)) return "impl";
+  if (/namespace|module|mod_item/.test(type)) return "module";
+  if (/method/.test(type)) return "method";
+  if (/function/.test(type)) return "function";
+  if (/rule_set|keyframes|media/.test(type)) return "rule";
+  return "def";
 }
 
 // --- chunk assembly ----------------------------------------------------------
@@ -287,15 +371,41 @@ function packSegments(lines: string[], breakRows: number[]): Array<[number, numb
   return spans;
 }
 
-/** Markdown: break at #/##/### headings, then pack like code segments. */
-function markdownBreaks(lines: string[]): number[] {
-  const rows: number[] = [];
+/** Markdown: break at #/##/### headings; each heading becomes a def site whose
+ * name is the heading text and scope is the ancestor-heading breadcrumb. */
+function markdownDefs(lines: string[]): DefSite[] {
+  const sites: DefSite[] = [];
+  const stack: Array<{ level: number; name: string }> = [];
   let inFence = false;
   for (let i = 0; i < lines.length; i++) {
-    if (/^\s*(```|~~~)/.test(lines[i])) inFence = !inFence;
-    else if (!inFence && /^#{1,3}\s/.test(lines[i])) rows.push(i);
+    if (/^\s*(```|~~~)/.test(lines[i])) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = lines[i].match(/^(#{1,3})\s+(.*)/);
+    if (!m) continue;
+    const level = m[1].length;
+    const name = m[2].trim().slice(0, 80);
+    while (stack.length && stack[stack.length - 1].level >= level) stack.pop();
+    sites.push({ row: i, name, kind: "section", scope: stack.map((s) => s.name).join(" › ") });
+    stack.push({ level, name });
   }
-  return rows;
+  return sites;
+}
+
+/** The primary symbol/kind/scope for a chunk: the definition sites that *start*
+ * within the chunk's line range. A continuation window of a large definition
+ * has none, and that's fine - it just carries no symbol. */
+function spanMeta(defs: DefSite[], startLine: number, endLine: number): Partial<Chunk> | undefined {
+  const inSpan = defs.filter((d) => d.row + 1 >= startLine && d.row + 1 <= endLine);
+  if (inSpan.length === 0) return undefined;
+  const names = [...new Set(inSpan.map((d) => d.name).filter(Boolean))];
+  return {
+    symbol: names.join(", ").slice(0, 120) || undefined,
+    kind: inSpan[0].kind,
+    scope: inSpan[0].scope || undefined,
+  };
 }
 
 export async function chunkFile(path: string, content: string): Promise<Chunk[]> {
@@ -303,21 +413,22 @@ export async function chunkFile(path: string, content: string): Promise<Chunk[]>
   const lang = langFor(path);
   const lines = content.split("\n");
 
+  let defs: DefSite[] | undefined;
   let spans: Array<[number, number]>;
   if (lang === "md") {
-    spans = packSegments(lines, markdownBreaks(lines));
+    defs = markdownDefs(lines);
+    spans = packSegments(lines, defs.map((d) => d.row));
   } else {
-    const breaks = await syntacticBreaks(lang, content);
-    spans = breaks !== undefined && breaks.length > 0
-      ? packSegments(lines, breaks)
-      : fixedWindows(lines, 1);
+    defs = await syntacticDefs(lang, content);
+    spans = defs && defs.length > 0 ? packSegments(lines, defs.map((d) => d.row)) : fixedWindows(lines, 1);
   }
 
   const chunks: Chunk[] = [];
   for (const [startLine, endLine] of spans) {
     const text = lines.slice(startLine - 1, endLine).join("\n");
     if (!text.trim()) continue;
-    chunks.push({ path, startLine, endLine, lang, content: text });
+    const meta = defs ? spanMeta(defs, startLine, endLine) : undefined;
+    chunks.push({ path, startLine, endLine, lang, content: text, ...meta });
   }
   return chunks;
 }

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -13,8 +13,8 @@ import { join, relative, sep } from "node:path";
 import { IndexSpec, type Connection, type OptimizeOptions } from "@infino-ai/infino";
 import { APPEND_BATCH, EMBED_BATCH, N_CENT, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
 import { walkRepo } from "./walker.js";
-import { shouldIndexFile, chunkFile, looksBinary, type Chunk } from "./chunker.js";
-import { readManifest, writeManifest, type Manifest, type VectorState } from "./manifest.js";
+import { shouldIndexFile, chunkFile, looksBinary, embedText, type Chunk } from "./chunker.js";
+import { readManifest, writeManifest, INDEX_FORMAT_VERSION, type Manifest, type VectorState } from "./manifest.js";
 import {
   diffFiles,
   emptyFileState,
@@ -61,6 +61,7 @@ const TEXT_SCHEMA = {
   start_line: "int32",
   end_line: "int32",
   lang: "large_utf8",
+  symbol: "large_utf8",
   content: "large_utf8",
 } as const;
 
@@ -160,7 +161,7 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
       const vectors: number[][] = [];
       for (let i = 0; i < chunks.length; i += EMBED_BATCH) {
         const batch = chunks.slice(i, i + EMBED_BATCH);
-        vectors.push(...(await embedder.embed(batch.map((c) => c.content))));
+        vectors.push(...(await embedder.embed(batch.map(embedText))));
         onProgress?.(Math.min(i + EMBED_BATCH, chunks.length), chunks.length);
       }
 
@@ -316,7 +317,7 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
     vectors = [];
     for (let i = 0; i < freshChunks.length; i += EMBED_BATCH) {
       const batch = freshChunks.slice(i, i + EMBED_BATCH);
-      vectors.push(...(await embedder.embed(batch.map((c) => c.content))));
+      vectors.push(...(await embedder.embed(batch.map(embedText))));
       opts.onProgress?.(Math.min(i + EMBED_BATCH, freshChunks.length), freshChunks.length);
     }
   }
@@ -444,13 +445,14 @@ function toTextRow(c: Chunk) {
     start_line: c.startLine,
     end_line: c.endLine,
     lang: c.lang,
+    symbol: c.symbol ?? "",
     content: c.content,
   };
 }
 
 function toManifest(stats: IndexStats, embedder?: Manifest["embedder"]): Manifest {
   return {
-    version: 1,
+    version: INDEX_FORMAT_VERSION,
     table: TABLE,
     vectors: stats.vectors,
     ...(embedder ? { embedder } : {}),

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -11,6 +11,11 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { MANIFEST_NAME, TABLE } from "./config.js";
 
+/** On-disk index format. Bump when the table schema or the embedded text
+ * changes so old indexes are treated as absent and rebuilt, never mixed:
+ *   1 -> 2: added the `symbol` column and enriched (contextual) embed text. */
+export const INDEX_FORMAT_VERSION = 2;
+
 /** How far the vector half of the index has progressed. */
 export type VectorState = "none" | "building" | "ready";
 
@@ -23,7 +28,7 @@ export interface EmbedderInfo {
 }
 
 export interface Manifest {
-  version: 1;
+  version: number;
   /** Table name the index lives in (always `chunks` today). */
   table: string;
   vectors: VectorState;
@@ -54,7 +59,9 @@ export function readManifest(indexDirPath: string): Manifest | undefined {
   try {
     const raw = readFileSync(manifestPath(indexDirPath), "utf8");
     const parsed = JSON.parse(raw) as Manifest;
-    if (parsed.version !== 1 || typeof parsed.table !== "string") return undefined;
+    // A manifest from an older format reads as absent, so the index rebuilds
+    // rather than being queried with a stale schema / raw-embedded vectors.
+    if (parsed.version !== INDEX_FORMAT_VERSION || typeof parsed.table !== "string") return undefined;
     return parsed;
   } catch {
     return undefined;
@@ -68,7 +75,7 @@ export function writeManifest(indexDirPath: string, manifest: Manifest): void {
 
 export function emptyManifest(): Manifest {
   return {
-    version: 1,
+    version: INDEX_FORMAT_VERSION,
     table: TABLE,
     vectors: "none",
     files: 0,

--- a/src/core/searcher.ts
+++ b/src/core/searcher.ts
@@ -59,6 +59,8 @@ export interface SearchHit {
   lang: string;
   score: number;
   content: string;
+  /** Definition name(s) in this chunk (e.g. "parseConfig"), when known. */
+  symbol?: string;
   /** Set when content was capped - Read path:startLine-endLine for the rest. */
   truncated?: boolean;
 }
@@ -77,7 +79,7 @@ export interface SearchResult {
   partial?: PartialIndex;
 }
 
-const PROJECTION = ["path", "start_line", "end_line", "lang", "content", "score"];
+const PROJECTION = ["path", "start_line", "end_line", "lang", "symbol", "content", "score"];
 
 export async function search(
   handle: IndexHandle,
@@ -114,6 +116,7 @@ export async function search(
         endLine: Number(r.end_line),
         lang: String(r.lang ?? ""),
         score: Number(r.score),
+        ...(r.symbol ? { symbol: String(r.symbol) } : {}),
         content: full.slice(0, HIT_CONTENT_CAP),
         ...(full.length > HIT_CONTENT_CAP ? { truncated: true } : {}),
       };

--- a/test/chunker.test.ts
+++ b/test/chunker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { chunkFile, langFor, looksBinary, shouldIndexFile } from "../src/core/chunker.js";
+import { chunkFile, embedText, langFor, looksBinary, shouldIndexFile } from "../src/core/chunker.js";
 
 describe("shouldIndexFile", () => {
   it("accepts source files and known basenames", () => {
@@ -57,6 +57,21 @@ describe("chunkFile", () => {
     }
   });
 
+  it("cuts bash, css, and powershell at definition boundaries", async () => {
+    const cases = [
+      { path: "script.sh", re: /^f\d\(\) \{/, code: Array.from({ length: 6 }, (_, i) => `f${i}() {\n${"  echo body\n".repeat(15)}}`).join("\n") },
+      { path: "styles.css", re: /^\.cls\d/, code: Array.from({ length: 8 }, (_, i) => `.cls${i} {\n${"  color: red;\n".repeat(8)}}`).join("\n") },
+      { path: "mod.ps1", re: /^function Get-Thing\d/, code: Array.from({ length: 5 }, (_, i) => `function Get-Thing${i} {\n${"  Write-Output 1\n".repeat(15)}}`).join("\n") },
+    ];
+    for (const { path, re, code } of cases) {
+      const chunks = await chunkFile(path, code);
+      expect(chunks.length).toBeGreaterThan(1);
+      // Every chunk begins exactly on a definition line (fixed-window fallback
+      // would start mid-block on the overlapping windows).
+      for (const c of chunks) expect(c.content.split("\n")[0]).toMatch(re);
+    }
+  });
+
   it("splits markdown at headings", async () => {
     const md = ["# Title", ...Array(70).fill("text"), "## Second", ...Array(10).fill("more")].join("\n");
     const chunks = await chunkFile("doc.md", md);
@@ -83,5 +98,44 @@ describe("chunkFile", () => {
   it("carries the path and language on every chunk", async () => {
     const chunks = await chunkFile("src/x.py", "def f():\n    return 1\n");
     expect(chunks[0]).toMatchObject({ path: "src/x.py", lang: "py", startLine: 1 });
+  });
+
+  it("attaches symbol names and enclosing scope from the AST", async () => {
+    const method = (n: number) => `  m${n}() {\n${"    doThing();\n".repeat(40)}  }`;
+    const src = `class C {\n${[0, 1, 2].map(method).join("\n")}\n}`;
+    const chunks = await chunkFile("cfg.ts", src);
+    // A chunk holding a method (but not the class opener) is scoped to the class.
+    const scoped = chunks.find((c) => c.scope === "C" && /m\d/.test(c.symbol ?? ""));
+    expect(scoped).toBeDefined();
+  });
+
+  it("carries the markdown heading as symbol, nested under its parent", async () => {
+    const md = ["# Title", ...Array(70).fill("text"), "## Second", ...Array(10).fill("more")].join("\n");
+    const chunks = await chunkFile("doc.md", md);
+    expect(chunks.some((c) => c.symbol === "Title")).toBe(true);
+    const second = chunks.find((c) => c.content.startsWith("## Second"));
+    expect(second?.symbol).toBe("Second");
+    expect(second?.scope).toBe("Title");
+  });
+
+  it("leaves symbol unset for fixed-window (unparsed) chunks", async () => {
+    const content = Array.from({ length: 150 }, (_, i) => `line ${i}`).join("\n");
+    const chunks = await chunkFile("data.toml", content);
+    expect(chunks.every((c) => c.symbol === undefined)).toBe(true);
+  });
+});
+
+describe("embedText", () => {
+  it("prepends path + breadcrumb, leaving content raw", () => {
+    const c = { path: "src/x.ts", startLine: 5, endLine: 9, lang: "ts", content: "function f() {}", symbol: "f", scope: "Mod" };
+    const t = embedText(c);
+    expect(t.startsWith("src/x.ts\nMod › f\n")).toBe(true);
+    expect(t.endsWith("function f() {}")).toBe(true);
+    expect(c.content).toBe("function f() {}"); // content itself untouched
+  });
+
+  it("falls back to just the path header when there is no symbol/scope", () => {
+    const t = embedText({ path: "a.txt", startLine: 1, endLine: 1, lang: "txt", content: "hi" });
+    expect(t).toBe("a.txt\nhi");
   });
 });


### PR DESCRIPTION
## What

- **Syntactic chunking for Bash, CSS, and PowerShell** — grammars already bundled in `@vscode/tree-sitter-wasm`, so no new dependency. Takes definition-boundary (tree-sitter) chunking from 11 to 14 languages; everything else still falls back to fixed windows.
- **AST-context embeddings.** Each chunk is embedded with a compact, deterministic header prepended to its content — `path › enclosing scope › symbol` — which sharpens the vector the way Anthropic's contextual retrieval does, but built from the AST rather than an LLM. The **returned content stays raw bytes**, so `path:line` citations remain exact.
- **`symbol` column.** The primary defined name(s) in each chunk (function/class/heading) are captured and surfaced on search hits.
- **`CX_EMBED_RAW=1`** disables enrichment — an eval lever, in the spirit of the existing `CX_EMBED_MODEL`.

## Evidence

Vector-only recall on the `infino` corpus (15 paraphrase queries, gold-file identifiers deliberately avoided):

| | vector-only hit@5 / MRR |
|---|---|
| raw embeddings | 10/15 · 0.589 |
| enriched embeddings | **12/15 · 0.639** |

Hybrid (BM25+vector) differences were within noise at n=15. The new grammars are tested to cut at definition boundaries.

## Migration

On-disk index format bumped to **v2** (adds the `symbol` column and enriched vectors). Older indexes read as absent and rebuild automatically — no user action.

## Tests

Added chunker coverage for the three new grammars and for symbol/scope extraction, markdown-heading symbols, fixed-window fallback, and `embedText` composition. Full suite: 90/90.
