### PR TITLE
bench + CI: retrieval recall gate + session-drift invocation harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,21 @@ jobs:
         run: npm run build
       - name: Test
         run: npm test
+
+  recall:
+    name: Recall (report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      # Retrieval-quality signal over the code-context corpus itself. Local
+      # embedder, no API key. Report-only: prints hit@5 / MRR@5 to the log and
+      # never fails the build (a soft floor can come later once stable).
+      - name: Recall report
+        run: node bench/recall.mjs

--- a/.github/workflows/invocation.yml
+++ b/.github/workflows/invocation.yml
@@ -1,0 +1,40 @@
+name: Invocation bench (manual)
+
+# Manual-only: runs real Claude agent sessions (costs Anthropic tokens), so it
+# never runs on a schedule or per PR - trigger it from the Actions tab when you
+# want fresh tool-invocation numbers. Report-only; it prints recall/specificity
+# to the log and does not gate anything.
+#
+# Requires the ANTHROPIC_API_KEY repo secret. Note: this is a partial-fidelity
+# run - a CI runner has no ~/.claude config, so code-context is injected via
+# INJECT_LOCAL_CX and competes only against the built-in file tools, not your
+# real MCP set. The faithful "all my MCPs loaded" run is `node bench/run-session.mjs`
+# on your own machine.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  invocation:
+    name: Session-drift invocation (report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install + build code-context
+        run: |
+          npm ci
+          npm run build
+      - name: Clone + index the infino corpus
+        run: |
+          git clone --depth 1 https://github.com/infino-ai/infino /tmp/infino
+          node dist/cli.js index /tmp/infino
+      - name: Install bench deps
+        run: npm install --prefix bench
+      - name: Run realistic-session invocation
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INJECT_LOCAL_CX: "1"
+        run: node bench/run-session.mjs /tmp/infino

--- a/bench/questions/session-drift.json
+++ b/bench/questions/session-drift.json
@@ -1,0 +1,15 @@
+{
+  "description": "One continuous developer session (shared context via resume) that mimics a real morning: comms/planning drift, git chores, a docs lookup, and a concept refresher interleaved between the actual codebase questions. Tests whether code-context still gets auto-invoked on the codebase turns AFTER context has drifted through other MCP servers and tools, and correctly stays out of the non-repo turns. `expect`: fire = code-context should be used; nofire = it should not; ambiguous = either.",
+  "turns": [
+    { "id": "slack-catchup",   "expect": "nofire",    "topic": "comms drift",    "q": "Morning. Anything urgent I missed overnight in our team Slack?" },
+    { "id": "calendar",        "expect": "nofire",    "topic": "planning drift",  "q": "What meetings do I have on my calendar today?" },
+    { "id": "git-status",      "expect": "nofire",    "topic": "git chore",       "q": "I'm working in the infino repo. What branch am I on and is anything uncommitted?" },
+    { "id": "vitest-docs",     "expect": "nofire",    "topic": "library docs",    "q": "Quick one - how do I make Vitest run only the tests affected by changed files?" },
+    { "id": "hybrid-scoring",  "expect": "fire",      "topic": "codebase",        "q": "Ok, back to the code. How does hybrid search here fuse the BM25 and vector scores?" },
+    { "id": "segment-merge",   "expect": "fire",      "topic": "codebase",        "q": "And where does the segment merge logic actually live?" },
+    { "id": "hnsw-concept",    "expect": "nofire",    "topic": "concept drift",   "q": "Remind me - what's the practical difference between HNSW and IVF for vector indexes?" },
+    { "id": "sql-param-parse", "expect": "fire",      "topic": "codebase",        "q": "Is there already code in this repo that parses SQL query parameters, or would I be writing it from scratch?" },
+    { "id": "tokenization-agg","expect": "fire",      "topic": "codebase",        "q": "Which files carry the most of the tokenization logic?" },
+    { "id": "slack-writeup",   "expect": "nofire",    "topic": "comms drift",     "q": "Nice. Draft a two-line summary of what we just found that I could drop in Slack." }
+  ]
+}

--- a/bench/recall.mjs
+++ b/bench/recall.mjs
@@ -1,0 +1,88 @@
+// Recall / ranking eval, run on each PR (report-only, no API key).
+//
+// Indexes THIS repo (code-context) to a temp dir with the default local
+// embedder, then runs a fixed set of paraphrase queries whose gold file is
+// known, and reports hit@5 / MRR@5 for vector-only ranking (isolates the
+// embedder) and hybrid ranking (the `search` tool's real surface).
+//
+// It's deterministic (same model+dtype -> same vectors) and needs no network
+// beyond the one-time model download, which makes it a good regression signal.
+// Report-only for now: it always exits 0; the numbers show in the CI log.
+//
+// Run locally: `npm run build && node bench/recall.mjs`
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Paraphrase query -> the one file that should rank first. Worded to avoid the
+// file's literal identifiers so keyword matching can't carry the answer.
+const GOLD = [
+  ["split source files into chunks at function and class boundaries", "src/core/chunker.ts"],
+  ["walk the project tree while honoring ignore files", "src/core/walker.ts"],
+  ["blend keyword scoring and vector similarity into one ranked list", "src/core/searcher.ts"],
+  ["re-embed only the files that changed since the last run", "src/core/indexer.ts"],
+  ["the terse line summarizing how many tokens a query returned", "src/core/usage.ts"],
+  ["load a local sentence embedding model with no api key", "src/core/embedder.ts"],
+  ["the on-disk record of what the index holds and how fresh it is", "src/core/manifest.ts"],
+  ["expose the retrieval tools to an agent over standard input output", "src/mcp/server.ts"],
+  ["per-file fingerprints to detect which files were modified", "src/core/filestate.ts"],
+  ["aligned text table output for the terminal", "src/core/output.ts"],
+  ["keep one index connection per repo in a small lru cache", "src/mcp/repos.ts"],
+  ["the command line entry point that parses subcommands", "src/cli.ts"],
+];
+
+// Build the index for the current repo into a throwaway dir.
+const tmp = mkdtempSync(join(tmpdir(), "cx-recall-"));
+process.env.CX_INDEX_DIR = tmp;
+
+const { indexRepo } = await import(`${ROOT}/dist/core/indexer.js`);
+const { openForIndexing, openIndex } = await import(`${ROOT}/dist/core/context.js`);
+const { createEmbedder } = await import(`${ROOT}/dist/core/embedder.js`);
+const { search } = await import(`${ROOT}/dist/core/searcher.js`);
+const { TABLE, DEFAULT_CAPS } = await import(`${ROOT}/dist/core/config.js`);
+
+console.log(`indexing ${ROOT}`);
+const { root, dir, db } = openForIndexing(ROOT);
+const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: createEmbedder(), caps: DEFAULT_CAPS });
+console.log(`  ${stats.chunks} chunks / ${stats.files} files, vectors=${stats.vectors}\n`);
+
+const handle = openIndex(ROOT);
+const table = handle.db.openTable(TABLE);
+const embedder = createEmbedder();
+
+const rankOf = (rows, gold) => {
+  const files = [];
+  for (const r of rows) {
+    const p = String(r.path);
+    if (!files.includes(p)) files.push(p);
+  }
+  return files.findIndex((p) => p === gold) + 1; // 1-based; 0 = not in top files
+};
+
+let vHit = 0, vRr = 0, hHit = 0, hRr = 0;
+const misses = [];
+for (const [q, gold] of GOLD) {
+  const [vec] = await embedder.embed([q]);
+  const vRank = rankOf(table.vectorSearch("embedding", vec, 15, { projection: ["path"] }), gold);
+  if (vRank >= 1 && vRank <= 5) { vHit++; vRr += 1 / vRank; }
+  const hRank = rankOf((await search(handle, embedder, q, 15)).hits, gold);
+  if (hRank >= 1 && hRank <= 5) { hHit++; hRr += 1 / hRank; } else misses.push(`${gold}  ("${q}")`);
+}
+
+const n = GOLD.length;
+const pct = (x) => (x / n).toFixed(3);
+console.log(`recall over ${n} paraphrase queries (code-context corpus):`);
+console.log(`  vector-only   hit@5 ${vHit}/${n}   MRR@5 ${pct(vRr)}`);
+console.log(`  hybrid        hit@5 ${hHit}/${n}   MRR@5 ${pct(hRr)}`);
+if (misses.length) {
+  console.log(`  hybrid misses (gold not in top 5):`);
+  for (const m of misses) console.log(`    - ${m}`);
+}
+
+rmSync(tmp, { recursive: true, force: true });
+// Report-only: never fail the build. A soft floor can be added once the
+// numbers are stable across the CI OS/Node matrix.

--- a/bench/run-session.mjs
+++ b/bench/run-session.mjs
@@ -1,0 +1,144 @@
+// The realistic-session invocation benchmark.
+//
+// Unlike run-invocation.mjs (one hermetic query per question), this runs ONE
+// continuous conversation - shared context carried across turns via `resume` -
+// inside a reproduction of the developer's REAL environment:
+//   settingSources: ['user','project','local']  -> the actual ~/.claude config,
+//   no strictMcpConfig, no tool pin -> every configured MCP server (code-context
+//   competing against context7/slack/github/infino/... ), all plugins, skills,
+//   slash commands and subagents load, exactly as in a real client. MCP tools
+//   are NOT force-loaded into turn 1; the agent discovers and chooses them as
+//   it would live.
+//
+// The turn script interleaves drift (Slack, calendar, docs, a concept refresher)
+// between the codebase questions, so the codebase turns land AFTER context has
+// drifted through other tools. We measure, per turn, whether code-context fired,
+// and score recall / specificity over the drifted session.
+//
+// Usage: node run-session.mjs [repoPath] [turnsFile]
+//   repoPath   the repo under test (default ../../infino)
+//   turnsFile  default questions/session-drift.json
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { record, MODEL, BENCH } from "./lanes.mjs";
+
+const repoDir = resolve(process.argv[2] ?? process.env.CX_BENCH_REPO ?? join(BENCH, "..", "..", "infino"));
+const turnsFile = process.argv[3] ?? join(BENCH, "questions", "session-drift.json");
+const { turns } = JSON.parse(readFileSync(turnsFile, "utf8"));
+const MAX_TURNS_PER = Number(process.env.CX_SESSION_MAXTURNS ?? 30);
+
+// Opt-in: inject the LOCAL build as `code-context-local` with the alwaysLoad
+// _meta marker on, so we test the prototype inside the full real environment
+// (drift + all the user's servers/skills). The user's config only carries the
+// published `code-context` (deferred), so this is how the local build enters.
+const CX = resolve(BENCH, "..", "dist", "cli.js");
+const indexDir = join(repoDir, ".infino");
+const injectLocal = ["1", "true", "yes"].includes((process.env.INJECT_LOCAL_CX ?? "").toLowerCase());
+
+const system =
+  `You are a coding assistant in a developer's session. The current working ` +
+  `directory is a git checkout at ${repoDir}. Help with each request. Use ` +
+  `whatever tools are appropriate, or none if you don't need them.`;
+
+const baseOptions = {
+  model: MODEL,
+  cwd: repoDir,
+  systemPrompt: system,
+  settingSources: ["user", "project", "local"], // real config: all MCP/plugins/skills
+  permissionMode: "bypassPermissions",
+  maxTurns: MAX_TURNS_PER,
+  env: { ...process.env, IS_SANDBOX: "1" },
+  // deliberately NO strictMcpConfig and NO tools pin -> full real environment
+  ...(injectLocal
+    ? {
+        mcpServers: {
+          "code-context-local": {
+            command: "node",
+            args: [CX, "mcp"],
+            env: { ...process.env, CX_ROOT: repoDir, CX_INDEX_DIR: indexDir, CX_AUTO_SYNC: "0", CX_ALWAYS_LOAD: "1" },
+          },
+        },
+      }
+    : {}),
+};
+
+const isCx = (name) => name.startsWith("mcp__code-context");
+const shortName = (name) =>
+  name.startsWith("mcp__") ? name.replace(/^mcp__/, "").replace(/__/, ":") : name;
+
+async function runTurn(prompt, resumeId) {
+  const toolCalls = [];
+  let sessionId = resumeId ?? null;
+  let answer = "";
+  let error = null;
+  let initServers = null;
+  try {
+    for await (const m of query({
+      prompt,
+      options: resumeId ? { ...baseOptions, resume: resumeId } : baseOptions,
+    })) {
+      if (m.type === "system" && m.subtype === "init") {
+        initServers = (m.mcp_servers ?? []).map((s) => `${s.name}:${s.status}`);
+      }
+      if (m.type === "assistant") {
+        for (const b of m.message.content ?? []) {
+          if (b.type === "tool_use") toolCalls.push(b.name);
+          if (b.type === "text") answer = b.text;
+        }
+      }
+      if (m.type === "result") {
+        sessionId = m.session_id ?? sessionId;
+        if (m.result) answer = m.result;
+      }
+    }
+  } catch (err) {
+    error = String(err?.message ?? err).slice(0, 300);
+  }
+  return { toolCalls, sessionId, answer, error, initServers };
+}
+
+console.log(`model=${MODEL}  repo=${repoDir.split("/").pop()}  turns=${turns.length}  (real config: settingSources=user,project,local)\n`);
+
+const results = [];
+let resumeId = null;
+for (let i = 0; i < turns.length; i++) {
+  const t = turns[i];
+  process.stdout.write(`(${i + 1}/${turns.length}) [${t.expect}] ${t.id} (${t.topic}) … `);
+  const r = await runTurn(t.q, resumeId);
+  if (i === 0 && r.initServers) console.log(`\n   env mcp: ${r.initServers.join(", ")}`);
+  resumeId = r.sessionId ?? resumeId;
+  const cx = r.toolCalls.filter(isCx).map((n) => shortName(n).replace("code-context:", ""));
+  const fired = cx.length > 0;
+  let correct = null;
+  if (t.expect === "fire") correct = fired;
+  else if (t.expect === "nofire") correct = !fired;
+  const other = r.toolCalls.filter((n) => !isCx(n)).map(shortName);
+  results.push({ ...t, fired, correct, cx, allTools: r.toolCalls.map(shortName), error: r.error });
+  record("session-drift.jsonl", {
+    turn: i + 1, id: t.id, expect: t.expect, topic: t.topic,
+    fired, correct, cx, otherTools: other, error: r.error,
+    sessionId: resumeId, answer: r.answer.slice(0, 800), ts: new Date().toISOString(),
+  });
+  const mark = correct === null ? "·" : correct ? "✓" : "✗";
+  console.log(
+    `${mark} fired=${fired}` +
+      (cx.length ? ` {${cx.join(",")}}` : "") +
+      `  tools: ${other.length ? other.join(", ") : "(none)"}` +
+      (r.error ? "  ERR" : "")
+  );
+}
+
+// ---- score over the drifted session ----
+const fireQ = results.filter((r) => r.expect === "fire");
+const nofireQ = results.filter((r) => r.expect === "nofire");
+const recall = fireQ.length ? fireQ.filter((r) => r.fired).length / fireQ.length : null;
+const specificity = nofireQ.length ? nofireQ.filter((r) => !r.fired).length / nofireQ.length : null;
+const pct = (x) => (x === null ? "n/a" : `${Math.round(x * 100)}%`);
+
+console.log("\n──────── realistic-session summary ────────");
+console.log(`recall      (fired when it should):      ${pct(recall)}  (${fireQ.filter((r) => r.fired).length}/${fireQ.length})`);
+console.log(`specificity (stayed out when it should): ${pct(specificity)}  (${nofireQ.filter((r) => !r.fired).length}/${nofireQ.length})`);
+const misfires = results.filter((r) => r.correct === false);
+if (misfires.length) console.log(`misfires: ${misfires.map((r) => `${r.id}(${r.expect},fired=${r.fired})`).join(", ")}`);
+record("session-drift-summary.jsonl", { ts: new Date().toISOString(), model: MODEL, repo: repoDir, n: results.length, recall, specificity, misfires: misfires.map((r) => r.id) });


### PR DESCRIPTION
Benchmark + CI tooling for retrieval quality and tool-invocation, in two tiers by cost.

## 1. Per-PR retrieval recall — deterministic, no key ✅
`bench/recall.mjs` indexes the code-context repo with the local embedder and reports **hit@5 / MRR@5** over paraphrase gold queries (vector-only + hybrid). A `recall` CI job runs it on **every PR, report-only** (prints to the log, never fails the build). Sample: `vector-only 11/12 · MRR 0.694`, `hybrid 10/12 · MRR 0.688`. No API key, deterministic → safe as a per-PR signal.

## 2. Realistic-session invocation harness — local 🖥️
`bench/run-session.mjs` + `bench/questions/session-drift.json` run one **continuous conversation in the developer's real environment** (`settingSources: user/project/local` → every configured MCP server loaded), scoring per-turn whether code-context **fires** on codebase turns and **stays out** on drift turns (Slack/calendar/git/docs). Local by design — its fidelity is the real `~/.claude` MCP set, which CI can't reproduce.

## 3. Manual invocation workflow — on-demand, agentic 🔘
`.github/workflows/invocation.yml` (`workflow_dispatch` **only** — no schedule, no per-PR, **zero recurring Anthropic cost**) runs a partial-fidelity CI version: clones + indexes the infino corpus, injects the local code-context build, runs session-drift, reports recall/specificity. **Needs the `ANTHROPIC_API_KEY` secret.**

### To activate #3
Add `ANTHROPIC_API_KEY` as a repo Actions secret, then trigger from the Actions tab. The first run also validates whether the agent SDK runs headless in CI (unverified).

## Cleanup
Removed throwaway bench probes (`probe-*.mjs`, `run-*-ab.mjs`, `run-invocation.mjs`) and the redundant `invocation*.json` sets; consolidated to `session-drift.json`.
