### PR TITLE
Release 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,27 @@ the same engine handles logs, docs, and agent memory.
 
 ## Quick start
 
-Add it to Claude Code with one command, nothing to install:
+Install the Claude Code plugin - nothing to paste into a config:
+
+```
+/plugin marketplace add infino-ai/code-context
+/plugin install code-context@infino-ai
+```
+
+It registers code-context's three tools with `alwaysLoad` already set, so the
+agent keeps them in view and reaches for the index directly instead of falling
+back to plain file search.
+
+Not on Claude Code, or prefer a one-line command? Add it as an MCP server:
 
 ```
 claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'
 ```
 
-The `alwaysLoad` flag keeps code-context's three tools in the agent's view. In
-a setup with many MCP servers, clients defer tool definitions behind a
-tool-search step, and the agent can miss the index and fall back to plain file
-search; `alwaysLoad` pins this small tool set so it reaches for the index
-directly. Prefer the shorter form and don't need that? `claude mcp add
-code-context -- npx -y @infino-ai/code-context mcp` works too (tools stay
-deferred). There's also a [plugin](#setup-for-agents) that bakes this in.
+The `alwaysLoad` flag pins this small tool set so that in a setup with many MCP
+servers - where clients defer tool definitions behind a tool-search step - the
+agent doesn't miss the index and fall back to plain file search. (Use *either*
+the plugin or this command, not both.)
 
 Then just ask a question about the code. The first `search` or `sql` on an
 unindexed repo builds the index inline and answers on the same call: keyword
@@ -162,6 +170,16 @@ agent.
 <details>
 <summary><strong>Claude Code</strong></summary>
 
+**Install as a plugin** - `alwaysLoad` already set, nothing to paste into a
+config:
+
+```
+/plugin marketplace add infino-ai/code-context
+/plugin install code-context@infino-ai
+```
+
+**Or register it as an MCP server** directly:
+
 ```bash
 claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino-ai/code-context","mcp"],"alwaysLoad":true}'
 ```
@@ -170,17 +188,8 @@ claude mcp add-json code-context -s user '{"command":"npx","args":["-y","@infino
 for the index directly. In sessions with many MCP servers Claude Code defers
 tool definitions behind a tool-search step; without `alwaysLoad` the agent can
 miss code-context and fall back to grep/read. It's a small, always-loaded set
-(three tools), so this is the recommended setup. Omit it (or use the shorter
-`claude mcp add code-context -- npx -y @infino-ai/code-context mcp`) if you'd
-rather leave the tools deferred.
-
-**Or install as a plugin** for the same effect with `alwaysLoad` already set,
-nothing to paste into a config:
-
-```
-/plugin marketplace add infino-ai/code-context
-/plugin install code-context@infino-ai
-```
+(three tools). Omit it (or use the shorter `claude mcp add code-context -- npx
+-y @infino-ai/code-context mcp`) if you'd rather leave the tools deferred.
 
 Use *either* the plugin or the `add-json` command, not both. They register the
 same `code-context` server, so running both just collides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infino-ai/code-context",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@infino-ai/code-context",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/code-context",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "mcpName": "io.github.infino-ai/code-context",
   "description": "Local code search for AI coding agents: a CLI and MCP server with hybrid keyword + semantic search and SQL relevance-ranked aggregation over an index that lives in plain files. No accounts, no keys, no server.",
   "license": "Apache-2.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/infino-ai/code-context",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@infino-ai/code-context",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ program
       "Keyword search seconds after `cx index`; semantic and hybrid search when vectors\n" +
       "finish backfilling; SQL with relevance-ranked aggregation over the whole repo.",
   )
-  .version("0.1.2")
+  .version("0.1.4")
   .addHelpText(
     "after",
     `


### PR DESCRIPTION
Release **0.1.4** + a README install reorg.

## Version bump
Bumps to `0.1.4` across `package.json`, `server.json` (both version fields), `src/cli.ts`, and the `package-lock` root.

This also **fixes the inconsistency that failed the release check**: the 0.1.3 bump moved `package.json` to 0.1.3 but left `server.json` and `cli.ts` at 0.1.2 (and the `v0.1.3` tag landed on a commit where `package.json` was still 0.1.2). 0.1.4 aligns all of them.

## README
Leads the install with the **Claude Code plugin** (before the `claude mcp add-json` command), in both the Quick start and the Setup-for-agents section — the plugin is the simplest path (`alwaysLoad` already set, nothing to paste), with the MCP command kept as the alternative.

## After merge
1. Draft a GitHub Release with tag **`v0.1.4`** pointing at the merge commit — `publish.yml` checks `tag == package.json version`, which now matches, and publishes to npm + the MCP registry.
2. The stale `v0.1.3` tag points at a 0.1.2 commit and was never published; delete it or just leave it unused.

`npm ci` clean, build clean, 90/90 tests.
