### PR TITLE
plugin: pin the npx version to the release; ship a usage skill

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "code-context": {
       "command": "npx",
-      "args": ["-y", "@infino-ai/code-context", "mcp"],
+      "args": ["-y", "@infino-ai/code-context@0.1.4", "mcp"],
       "alwaysLoad": true
     }
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ npm test          # vitest - unit + engine-integration tests, no network needed
 
 Publishing is release-driven and automated. Maintainers:
 
-1. Bump `version` in `package.json` on `main`.
+1. Bump the version on `main` in `package.json`, `.claude-plugin/plugin.json`,
+   and the `npx` pin in `.mcp.json` (`test/plugin.test.ts` keeps the three in
+   lockstep).
 2. Create a GitHub release with tag `vX.Y.Z` matching that version.
 3. CI publishes to npm (with provenance) and the MCP Registry. A tag that
    does not match `package.json` fails fast.

--- a/skills/code-context/SKILL.md
+++ b/skills/code-context/SKILL.md
@@ -37,9 +37,11 @@ listed names, comma-separated). Never load them one call at a time.
 - Pass terms, a phrase, or a plain-language description; one pass fuses BM25
   keyword matching with semantic similarity, so it works whether or not you
   know the exact words.
+- One good search beats several narrow ones - put both the identifiers you
+  know and the intent into a single query.
 - Every hit carries `path`, `startLine`-`endLine`, and the chunk content with
-  a relevance score - usually enough to answer without opening the file.
-  Cite results as `path:line`.
+  a relevance score. Answer from the chunk content when it suffices, citing
+  the `path:line` ranges; open a file only for what the chunks don't show.
 - If a hit is marked `truncated`, Read exactly its start-end range
   (offset/limit), not the whole file.
 - `k` (default 10) bounds hits; raise it for survey-style questions.
@@ -63,7 +65,7 @@ rank AND aggregate:
 The canonical move - "which files have the most code about X":
 
 ```sql
-SELECT path, SUM(end_line - start_line + 1) AS lines
+SELECT path, SUM(end_line - start_line + 1) AS lines, COUNT(*) AS chunks
 FROM bm25_search('chunks','content','<terms>', 300)
 GROUP BY path ORDER BY lines DESC LIMIT 15
 ```

--- a/skills/code-context/SKILL.md
+++ b/skills/code-context/SKILL.md
@@ -44,7 +44,7 @@ listed names, comma-separated). Never load them one call at a time.
   the `path:line` ranges; open a file only for what the chunks don't show.
 - If a hit is marked `truncated`, Read exactly its start-end range
   (offset/limit), not the whole file.
-- `k` (default 10) bounds hits; raise it for survey-style questions.
+- `k` (default 10, max 50) bounds hits; raise it for survey-style questions.
 - Until the index's vector stage finishes, results say they are
   keyword-ranked; they are still real, cited hits.
 
@@ -83,10 +83,19 @@ GROUP BY path ORDER BY lines DESC LIMIT 15
   is a new root and builds its own index on first query (the main checkout's
   index does not carry over).
 
+## Reading results honestly
+
+- A result carrying a `partial` marker means the repo exceeded the index's
+  file cap and some files were left out: treat a missing match as
+  possibly-unindexed, not as proof the code doesn't exist.
+- Search and sql results carry a one-line `usage` receipt (tokens returned,
+  chunks/files, session running total), computed locally. End your reply by
+  showing that line to the user verbatim.
+
 ## Multi-repo sessions
 
-Every tool takes an optional `path` (repo root) to target a different
-repository than the one the server started in.
+Every tool takes an optional `path` (an **absolute** repo root) to target a
+different repository than the one the server started in.
 
 ## Cost awareness
 

--- a/skills/code-context/SKILL.md
+++ b/skills/code-context/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: code-context
+description: >
+  How to answer codebase questions with the code-context MCP tools (search,
+  sql, reindex): ranked hybrid keyword+semantic search, relevance-ranked SQL
+  aggregation over the index, and index lifecycle. Use when a question spans
+  many files ("how does X work", "where is Y handled"), when ranking or
+  counting code by topic across a repo, or when the code-context tools are
+  present but deferred and need loading before use. Not needed for jumping
+  to one known identifier - plain grep is fine there.
+---
+
+# code-context: ranked search over the repository
+
+code-context maintains a local index of the repository (in `.infino/` at the
+repo root) and exposes three MCP tools. The more a question spans the repo,
+the more one ranked pass beats crawling files into context.
+
+## If the tools are deferred
+
+When the tool names appear in a deferred-tools listing but their schemas are
+not loaded, load all three in ONE ToolSearch call before the first use, e.g.
+query `+code-context search sql reindex` (or `select:` with the exact
+listed names, comma-separated). Never load them one call at a time.
+
+## Choosing the right tool
+
+| Situation | Use |
+| --- | --- |
+| One known identifier, literal string, or file | plain grep / file tools |
+| "How does X work", "where is Y handled", concept without exact name | `search` |
+| Counts, rankings, GROUP BY across the repo ("which files have the most code about X") | `sql` |
+| Working tree changed a lot mid-session | `reindex` (usually unnecessary - see lifecycle) |
+
+## search
+
+- Pass terms, a phrase, or a plain-language description; one pass fuses BM25
+  keyword matching with semantic similarity, so it works whether or not you
+  know the exact words.
+- Every hit carries `path`, `startLine`-`endLine`, and the chunk content with
+  a relevance score - usually enough to answer without opening the file.
+  Cite results as `path:line`.
+- If a hit is marked `truncated`, Read exactly its start-end range
+  (offset/limit), not the whole file.
+- `k` (default 10) bounds hits; raise it for survey-style questions.
+- Until the index's vector stage finishes, results say they are
+  keyword-ranked; they are still real, cited hits.
+
+## sql
+
+One read-only SELECT/WITH statement over the table
+`chunks(path, start_line, end_line, lang, symbol, content[, embedding])`.
+Search functions are callable as table-valued relations, so one query can
+rank AND aggregate:
+
+- `bm25_search('chunks','content','<terms>', k)` - keyword ranking, no
+  embedding needed.
+- `hybrid_search('chunks','content','<terms>','embedding', {{q}}, k)` and
+  `vector_search('chunks','embedding', {{q}}, k)` - take a `{{name}}`
+  placeholder filled via the `embed` argument, e.g. `{"q": "query text"}`.
+- `regexp_like(content, 'pattern')` works in WHERE.
+
+The canonical move - "which files have the most code about X":
+
+```sql
+SELECT path, SUM(end_line - start_line + 1) AS lines
+FROM bm25_search('chunks','content','<terms>', 300)
+GROUP BY path ORDER BY lines DESC LIMIT 15
+```
+
+## Index lifecycle (usually zero-touch)
+
+- **First query in a never-indexed repo auto-builds the index** and answers
+  on the same call: it returns as soon as keyword search is live (seconds),
+  while vectors backfill in the background. Do not pre-emptively reindex.
+- **Later queries auto-sync**: the server re-chunks only files that changed
+  since the last index. An unchanged tree is a fast no-op.
+- Call `reindex` explicitly only after sweeping working-tree changes you
+  want reflected immediately, or `full: true` to force a rebuild.
+- Each repo's index is keyed to its own root directory: a fresh git worktree
+  is a new root and builds its own index on first query (the main checkout's
+  index does not carry over).
+
+## Multi-repo sessions
+
+Every tool takes an optional `path` (repo root) to target a different
+repository than the one the server started in.
+
+## Cost awareness
+
+- `search`/`sql` calls are cheap (local, milliseconds).
+- The first index of a repo and the vector backfill are the expensive part
+  (CPU for the local embedding model, proportional to repo size). Avoid
+  forcing `full: true` rebuilds unless the index is actually wrong, and
+  avoid triggering first-time indexing of large repos that the task does
+  not need.

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// The Claude Code plugin launches the MCP server via `npx` with an exact
+// version pin. An unpinned spec lets `npx` prefer whatever copy is already
+// installed on the machine, so a user with a stale global install silently
+// gets old server behavior no matter what the plugin ships. The pin makes
+// the plugin version decide what runs; these guards keep it (and the plugin
+// manifest) in lockstep with the package version at each release.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) =>
+  JSON.parse(readFileSync(new URL(`../${path}`, import.meta.url), "utf8"));
+
+describe("claude code plugin release lockstep", () => {
+  const version = read("package.json").version as string;
+
+  it(".mcp.json pins the published package to this release", () => {
+    const args = read(".mcp.json").mcpServers["code-context"].args as string[];
+    expect(args).toContain(`@infino-ai/code-context@${version}`);
+  });
+
+  it("plugin manifest version matches the package version", () => {
+    expect(read(".claude-plugin/plugin.json").version).toBe(version);
+  });
+});


### PR DESCRIPTION
## Problem

The Claude Code plugin launches the MCP server with an unpinned spec:

```json
"args": ["-y", "@infino-ai/code-context", "mcp"]
```

`npx` prefers an already-installed copy over the registry, so any machine
with a stale global install silently runs that old server regardless of
what the plugin ships. Observed in practice: a box with a global 0.1.0
kept returning the strict "no index yet — call the reindex tool once"
error even though 0.1.4 (auto-index on first query, `src/mcp/ensure.ts`)
had been out for days. The first-use experience the release shipped never
reached the user, with no visible signal that anything was stale.

## Change

- Pin the exact published version in `.mcp.json`
  (`@infino-ai/code-context@0.1.4`) so the plugin release decides what
  runs. An exact pin also resolves from the npx cache, unlike `@latest`
  which re-checks the registry on every server start.
- Add `test/plugin.test.ts`: keeps `package.json`, the plugin manifest
  (`.claude-plugin/plugin.json`), and the `.mcp.json` pin in lockstep, so
  a release can't forget to move the pin.
- Update the release steps in `CONTRIBUTING.md` to name all three files.

Left as-is deliberately: the unpinned `npx` command in the README /
context7 install docs — manual `claude mcp add` users manage their own
version; the plugin is the surface we version.

## Also: ship a skill with the plugin

Until c712051 (0.1.1), `cx install` wrote a usage skill into the user's
`.claude/skills/`; dropping the installer in favor of the plugin also
dropped that guidance — the plugin registers only the MCP server. This
restores it, updated for 0.1.4 behavior.

Claude Code sessions increasingly defer MCP tool schemas and load them on
demand. The server's instructions only reach the model once its tools are
loaded, and they don't teach tool *choice*. New
`skills/code-context/SKILL.md` (auto-discovered — no manifest registration
needed) covers: loading the tools when deferred, search-vs-sql-vs-grep
choice, index SQL against the search table functions, the zero-touch index
lifecycle (auto-index on first query, auto-sync, per-root worktree
indexes), multi-repo `path` targeting, and cost awareness around
first-index/backfill.

## Testing

`npm run build` clean; `npm test` 92/92 passing (12 files), including the
two new lockstep guards.
