### PR TITLE
indexer: stream builds and syncs through on-disk spills (#9)

### DIFF
--- a/src/commands/index-cmd.ts
+++ b/src/commands/index-cmd.ts
@@ -10,7 +10,7 @@
 import { watch } from "node:fs";
 import { openForIndexing } from "../core/context.js";
 import { indexRepoStaged, syncRepo, type IndexOptions, type SyncResult } from "../core/indexer.js";
-import { createEmbedder, embedderInfo } from "../core/embedder.js";
+import { createEmbedder, createIndexingEmbedder, embedderInfo } from "../core/embedder.js";
 import { DEFAULT_CAPS, INDEX_DIR_NAME } from "../core/config.js";
 import { bold, dim, green, yellow, fmtMs, fmtCount, progressLine, progressDone } from "../core/output.js";
 
@@ -78,7 +78,10 @@ export async function indexCmd(path: string | undefined, opts: IndexCmdOptions):
   };
 
   const full = async (): Promise<void> => {
-    const run = await indexRepoStaged(baseOpts);
+    // Full builds embed in a child process (bulk arenas leave with it);
+    // sync keeps the in-process embedder for its small warm batches.
+    const buildEmb = opts.embed === false ? undefined : createIndexingEmbedder();
+    const run = await indexRepoStaged({ ...baseOpts, embedder: buildEmb });
     if (!opts.json) {
       progressDone();
       const t = run.text;
@@ -91,6 +94,7 @@ export async function indexCmd(path: string | undefined, opts: IndexCmdOptions):
       }
     }
     const final = await run.completion;
+    await buildEmb?.dispose?.()?.catch(() => undefined);
     if (opts.json) {
       console.log(JSON.stringify(final, null, 2));
       return;

--- a/src/core/chunker.ts
+++ b/src/core/chunker.ts
@@ -10,6 +10,7 @@
 
 import { createRequire } from "node:module";
 import { join, dirname } from "node:path";
+import { EMBED_MAX_CHARS } from "./config.js";
 
 export interface Chunk {
   path: string;
@@ -50,9 +51,15 @@ const RAW_EMBED = ["1", "true", "yes"].includes((process.env.CX_EMBED_RAW ?? "")
  * AST rather than an LLM. The header is never returned; results keep the raw
  * content, so citations stay exact. */
 export function embedText(c: Chunk): string {
-  if (RAW_EMBED) return c.content;
-  const crumb = [c.scope, c.symbol].filter(Boolean).join(" › ");
-  return crumb ? `${c.path}\n${crumb}\n${c.content}` : `${c.path}\n${c.content}`;
+  const text = RAW_EMBED
+    ? c.content
+    : (() => {
+        const crumb = [c.scope, c.symbol].filter(Boolean).join(" › ");
+        return crumb ? `${c.path}\n${crumb}\n${c.content}` : `${c.path}\n${c.content}`;
+      })();
+  // Cap what reaches the tokenizer: past the model's token window the extra
+  // characters never influence the vector, but they do grow the ONNX arenas.
+  return text.length > EMBED_MAX_CHARS ? text.slice(0, EMBED_MAX_CHARS) : text;
 }
 
 // Window tuning: target is the preferred chunk size; a single syntactic unit

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -46,6 +46,14 @@ export const APPEND_BATCH = 512;
 /** Chunks embedded per model call. */
 export const EMBED_BATCH = 32;
 
+/** Character cap on the text handed to the embedding model per chunk. The
+ * model truncates to its token window anyway (256 tokens for the default
+ * MiniLM), so anything past a few thousand characters never influences the
+ * vector - but it DOES size the tokenizer/ONNX arenas. Capping here bounds
+ * arena growth on pathological inputs (minified bundles, single-line data
+ * files) without changing retrieval. */
+export const EMBED_MAX_CHARS = Number(process.env.CX_EMBED_MAX_CHARS ?? 8000);
+
 /** IVF centroid count for the vector index. 1 = exact scan - perfect recall,
  * and at local-repo scale (tens of thousands of chunks) still milliseconds. */
 export const N_CENT = 1;

--- a/src/core/embed-worker.ts
+++ b/src/core/embed-worker.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Child-process embedding worker. The ONNX runtime's memory arenas grow with
+// everything ever embedded and never shrink, so full-build embedding runs
+// here, where process exit returns the memory to the OS - the long-lived MCP
+// server never hosts the bulk pipeline (issue #9).
+//
+// Protocol (lockstep with the parent - see createIndexingEmbedder): one
+// NDJSON request {texts: [...]} per line on stdin, one NDJSON response
+// {n, dim, b64} (base64 of packed row-major f32) or {error} on stdout.
+// stdin closing is the shutdown signal. stderr carries model logs.
+//
+// This file is a process entry point, not a module - it must stay
+// import-free of the rest of src/ so the parent can spawn it cold.
+
+import { createInterface } from "node:readline";
+
+const MODEL = process.env.CX_EMBED_MODEL ?? "Xenova/all-MiniLM-L6-v2";
+const DTYPE = process.env.CX_EMBED_DTYPE ?? "q8";
+
+/** Protocol-line marker; the parent ignores unprefixed stdout (e.g. a
+ * library's progress prints). Must match WORKER_LINE_PREFIX in embedder.ts
+ * (not imported - this file stays dependency-free of src/). */
+const LINE_PREFIX = "@cx:";
+
+type Extractor = (
+  texts: string[],
+  opts: object,
+) => Promise<{ data: Float32Array; dims: number[] }>;
+
+let pipe: Promise<Extractor> | null = null;
+function getPipe(): Promise<Extractor> {
+  if (!pipe) {
+    pipe = (async () => {
+      const { pipeline } = await import("@huggingface/transformers");
+      return (await pipeline("feature-extraction", MODEL, { dtype: DTYPE as never })) as never;
+    })();
+  }
+  return pipe;
+}
+
+// Requests are processed strictly in order (the parent is lockstep anyway);
+// chaining onto `tail` keeps responses ordered even if that ever changes.
+let tail = Promise.resolve();
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  tail = tail.then(async () => {
+    try {
+      const { texts } = JSON.parse(line) as { texts: string[] };
+      const extractor = await getPipe();
+      const output = await extractor(texts, { pooling: "mean", normalize: true });
+      const dim = output.dims[output.dims.length - 1];
+      const bytes = Buffer.from(output.data.buffer, output.data.byteOffset, output.data.byteLength);
+      process.stdout.write(
+        LINE_PREFIX + JSON.stringify({ n: texts.length, dim, b64: bytes.toString("base64") }) + "\n",
+      );
+    } catch (err) {
+      process.stdout.write(LINE_PREFIX + JSON.stringify({ error: (err as Error).message }) + "\n");
+    }
+  });
+});
+rl.on("close", () => {
+  void tail.finally(() => process.exit(0));
+});

--- a/src/core/embedder.ts
+++ b/src/core/embedder.ts
@@ -9,8 +9,21 @@
 // first and backfills vectors after, so a failed model download degrades to
 // keyword-only search instead of blocking indexing.
 //
+// Two embedders, one model:
+//   createEmbedder()          in-process pipeline; stays warm for query-time
+//                             embedding (one short string per call - arenas
+//                             stay small) and small incremental syncs.
+//   createIndexingEmbedder()  a short-lived child process for full builds;
+//                             the ONNX runtime's arenas grow with everything
+//                             ever embedded and never shrink, so bulk work
+//                             runs where exit() can give the memory back.
+//
 // CX_EMBED_MODEL / CX_EMBED_DTYPE exist for development and evaluation (see
 // docs/embedder-eval.md) and are deliberately undocumented product surface.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+import { fileURLToPath } from "node:url";
 
 export const LOCAL_MODEL_DEFAULT = "Xenova/all-MiniLM-L6-v2";
 const MODEL = process.env.CX_EMBED_MODEL ?? LOCAL_MODEL_DEFAULT;
@@ -20,11 +33,38 @@ const MODEL = process.env.CX_EMBED_MODEL ?? LOCAL_MODEL_DEFAULT;
 // (docs/embedder-eval.md).
 const DTYPE = (process.env.CX_EMBED_DTYPE ?? "q8") as "fp32" | "fp16" | "q8" | "q4";
 
+/** How long dispose() waits for a clean child exit before SIGKILL. */
+const CHILD_EXIT_GRACE_MS = 3000;
+
+/** Marks protocol lines on the worker's stdout; anything unprefixed (a
+ * library's stray progress print) is ignored instead of desyncing the
+ * lockstep protocol. Must match embed-worker.ts. */
+export const WORKER_LINE_PREFIX = "@cx:";
+
+/** Reply deadline once the model is warm. A wedged-but-alive worker must
+ * fail the vector stage (keyword search stays live), not pin the repo at
+ * vectors:"building" forever. 10 minutes for a 32-text batch is far past any
+ * healthy CPU inference; CX_EMBED_WORKER_TIMEOUT_MS raises it for genuinely
+ * slower setups (huge custom models via CX_EMBED_MODEL, loaded boxes). */
+const WORKER_REPLY_TIMEOUT_MS = Number(process.env.CX_EMBED_WORKER_TIMEOUT_MS ?? 10 * 60 * 1000);
+
+/** Reply deadline for the first round-trip, which may also include a full
+ * model download on a slow link. Never below the warm deadline. */
+const WORKER_FIRST_REPLY_TIMEOUT_MS = Math.max(15 * 60 * 1000, WORKER_REPLY_TIMEOUT_MS);
+
 export interface Embedder {
   /** Embed a batch of texts into vectors (one per text). */
   embed(texts: string[]): Promise<number[][]>;
+  /** Embed a batch into one packed row-major Float32Array (n × dim). The
+   * streaming index path prefers this: native f32 is half the bytes of boxed
+   * doubles and writes straight to the vector spill. Optional so test fakes
+   * and older embedders keep working via `embed`. */
+  embedToFloat32?(texts: string[]): Promise<{ vectors: Float32Array; dim: number }>;
   /** Vector dimension (learned from the first embedding when unknown). */
   dim(): Promise<number>;
+  /** Release resources (kill the child process / drop the pipeline). Only
+   * the creator of an embedder calls this. Optional and idempotent. */
+  dispose?(): Promise<void>;
   provider: string;
   model: string;
   /** Quantization the model runs at ("fp32", "q8", …). */
@@ -34,7 +74,7 @@ export interface Embedder {
 // Lazily load the pipeline once; the first call downloads + caches the model
 // under the transformers.js cache dir.
 let pipe: Promise<
-  (texts: string[], opts: object) => Promise<{ tolist(): number[][] }>
+  (texts: string[], opts: object) => Promise<{ data: Float32Array; dims: number[]; tolist(): number[][] }>
 > | null = null;
 function getPipe() {
   if (!pipe) {
@@ -48,19 +88,190 @@ function getPipe() {
 
 export function createEmbedder(): Embedder {
   let knownDim: number | undefined;
-  const embed = async (texts: string[]) => {
+  const embedToFloat32 = async (texts: string[]) => {
     const extractor = await getPipe();
     // Mean-pool token vectors and L2-normalize → one embedding per text.
     const output = await extractor(texts, { pooling: "mean", normalize: true });
-    const vectors = output.tolist();
-    knownDim ??= vectors[0]?.length;
-    return vectors;
+    // `data` is the tensor's backing Float32Array (row-major [n, dim]) - no
+    // per-float boxing, unlike tolist().
+    const dim = output.dims[output.dims.length - 1];
+    knownDim ??= dim;
+    return { vectors: output.data.slice() as Float32Array, dim };
+  };
+  const embed = async (texts: string[]) => {
+    const { vectors, dim } = await embedToFloat32(texts);
+    return unpackRows(vectors, dim);
   };
   return {
     embed,
+    embedToFloat32,
     dim: async () => {
-      if (knownDim === undefined) await embed(["probe"]);
+      if (knownDim === undefined) await embedToFloat32(["probe"]);
       return knownDim!;
+    },
+    provider: "local",
+    model: MODEL,
+    dtype: DTYPE,
+  };
+}
+
+/** Split a packed row-major Float32Array into number[] rows (the shape the
+ * engine binding's row-object append accepts). Bounded by the batch that
+ * produced it - never called on a whole corpus. */
+export function unpackRows(vectors: Float32Array, dim: number): number[][] {
+  const rows: number[][] = [];
+  for (let off = 0; off < vectors.length; off += dim) {
+    rows.push(Array.from(vectors.subarray(off, off + dim)));
+  }
+  return rows;
+}
+
+// --- child-process embedder for full builds ---------------------------------
+//
+// Protocol (lockstep, one in flight): parent writes one NDJSON request line
+// {texts: [...]} to the child's stdin and awaits one NDJSON response line
+// {n, dim, b64} (b64 = base64 of the packed f32 rows) or {error} on stdout.
+// Model logs go to stderr. stdin end = shutdown. Lockstep means no pipe
+// backpressure handling and strictly bounded child memory.
+
+interface WorkerOk {
+  n: number;
+  dim: number;
+  b64: string;
+}
+
+/** A build-scoped embedder that runs the model in a child process and gives
+ * the memory back on dispose(). Falls back to the in-process embedder if the
+ * child can't start (missing dist worker when running from source, exotic
+ * node setups) - indexing never fails over process plumbing. */
+export function createIndexingEmbedder(): Embedder {
+  let child: ChildProcess | null = null;
+  let lines: Interface | null = null;
+  let pending: Array<{ resolve: (line: string) => void; reject: (err: Error) => void }> = [];
+  let fallback: Embedder | null = null;
+  let knownDim: number | undefined;
+  let disposed = false;
+
+  const start = () => {
+    const workerPath = fileURLToPath(new URL("./embed-worker.js", import.meta.url));
+    const proc = spawn(process.execPath, [workerPath], {
+      stdio: ["pipe", "pipe", "inherit"],
+      env: process.env,
+    });
+    const rl = createInterface({ input: proc.stdout! });
+    rl.on("line", (line) => {
+      // Only prefixed lines are protocol; a dependency printing to stdout
+      // must not shift the lockstep pairing.
+      if (line.startsWith(WORKER_LINE_PREFIX)) {
+        pending.shift()?.resolve(line.slice(WORKER_LINE_PREFIX.length));
+      }
+    });
+    const fail = (why: string) => {
+      const waiting = pending;
+      pending = [];
+      for (const p of waiting) p.reject(new Error(why));
+    };
+    proc.on("error", (err) => fail(`embed worker failed to start: ${err.message}`));
+    proc.on("exit", (code) => {
+      if (!disposed && code !== 0) fail(`embed worker exited with code ${code}`);
+    });
+    child = proc;
+    lines = rl;
+  };
+
+  let firstReply = true;
+  const roundTrip = (texts: string[]): Promise<WorkerOk> => {
+    const timeoutMs = firstReply ? WORKER_FIRST_REPLY_TIMEOUT_MS : WORKER_REPLY_TIMEOUT_MS;
+    firstReply = false;
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // The lockstep pairing is unrecoverable after a missed reply; kill
+        // the worker so the failure is prompt and the process can't linger.
+        reject(new Error(`embed worker unresponsive for ${Math.round(timeoutMs / 60000)}m`));
+        void stopChild();
+      }, timeoutMs);
+      timer.unref();
+      pending.push({
+        resolve: (line) => {
+          clearTimeout(timer);
+          resolve(line);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+      child!.stdin!.write(JSON.stringify({ texts }) + "\n", (err) => {
+        if (err) pending.shift()?.reject(err);
+      });
+    }).then((line) => {
+      const msg = JSON.parse(line) as WorkerOk | { error: string };
+      if ("error" in msg) throw new Error(`embed worker: ${msg.error}`);
+      return msg;
+    });
+  };
+
+  const embedToFloat32 = async (texts: string[]) => {
+    if (fallback) return fallback.embedToFloat32!(texts);
+    if (!child) {
+      try {
+        start();
+        // Prove the pipeline works before trusting the child with the run;
+        // a dead worker surfaces here, once, instead of on every batch.
+        const probe = await roundTrip(["probe"]);
+        knownDim ??= probe.dim;
+      } catch (err) {
+        process.stderr.write(
+          `code-context: embed worker unavailable (${(err as Error).message}); embedding in-process\n`,
+        );
+        await stopChild();
+        fallback = createEmbedder();
+        return fallback.embedToFloat32!(texts);
+      }
+    }
+    const msg = await roundTrip(texts);
+    knownDim ??= msg.dim;
+    // Copy out of the (possibly pooled, unaligned) base64 Buffer into an
+    // owned, 4-byte-aligned array. Bounded by one batch.
+    const bytes = Buffer.from(msg.b64, "base64");
+    const vectors = new Float32Array(bytes.byteLength / 4);
+    new Uint8Array(vectors.buffer).set(bytes);
+    return { vectors, dim: msg.dim };
+  };
+
+  const stopChild = async () => {
+    const proc = child;
+    child = null;
+    lines?.close();
+    lines = null;
+    if (!proc) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        proc.kill("SIGKILL");
+        resolve();
+      }, CHILD_EXIT_GRACE_MS);
+      proc.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      proc.stdin?.end();
+    });
+  };
+
+  return {
+    embed: async (texts) => {
+      const { vectors, dim } = await embedToFloat32(texts);
+      return unpackRows(vectors, dim);
+    },
+    embedToFloat32,
+    dim: async () => {
+      if (knownDim === undefined) await embedToFloat32(["probe"]);
+      return knownDim!;
+    },
+    dispose: async () => {
+      disposed = true;
+      await stopChild();
+      fallback = null;
     },
     provider: "local",
     model: MODEL,

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -7,10 +7,45 @@
 // vector index; hybrid/semantic search unlocks when it lands. The table name
 // never changes, so SQL written against `chunks` keeps working across stages;
 // the manifest records how far the index has progressed.
+//
+// Both stages STREAM (issue #9): peak memory scales with one batch, not the
+// repo. Chunks spool to an on-disk NDJSON spill as files are walked (the
+// live table is untouched during the walk), embeddings stream through the
+// embedder into a packed-f32 spill, and every table (re)build replays the
+// spills in bounded waves. Each build owns uniquely-named spills, deleted
+// when its vector stage settles either way.
+//
+// Two invariants the streaming must not soften:
+//   - Table swaps are ATOMIC to same-process readers: every drop → create →
+//     append sequence runs in one synchronous block (no awaits), exactly like
+//     the pre-streaming code. Spill reads inside those blocks are sync I/O.
+//   - Failures leave the previous index standing. Chunk-spill errors abort
+//     before any drop; embed errors surface before pass B's drop; sync embeds
+//     before it deletes a single row.
 
-import { readFileSync, appendFileSync, existsSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  type WriteStream,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
 import { join, relative, sep } from "node:path";
-import { IndexSpec, type Connection, type OptimizeOptions } from "@infino-ai/infino";
+import { StringDecoder } from "node:string_decoder";
+import { IndexSpec, type Connection, type OptimizeOptions, type RowRecord } from "@infino-ai/infino";
 import { APPEND_BATCH, EMBED_BATCH, N_CENT, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
 import { walkRepo } from "./walker.js";
 import { shouldIndexFile, chunkFile, looksBinary, embedText, type Chunk } from "./chunker.js";
@@ -28,12 +63,33 @@ import type { Embedder } from "./embedder.js";
 const COMPACTION_TARGET_MIB =
   parseInt(process.env.CX_COMPACTION_TARGET_MIB ?? "", 10) || 10;
 
+/** Spill filename prefix; full names are `spill.<pid>-<token>.<seq>.{chunks
+ * .ndjson,vectors.f32}` so concurrent builds (same process, or a CLI racing
+ * the MCP server) never share files. The random token disambiguates equal
+ * pids across PID namespaces (two containers bind-mounting one repo are both
+ * pid 1) - a bare-pid "mine" test would let one instantly sweep the other's
+ * live spills. */
+const SPILL_PREFIX = "spill.";
+const SPILL_OWNER = `${SPILL_PREFIX}${process.pid}-${randomBytes(3).toString("hex")}.`;
+
+/** Another process's leftover spills are swept only past this age - young
+ * ones may belong to its live backfill. Our own dead spills sweep instantly
+ * (the in-process registry knows which are live). */
+const STALE_SPILL_MS = 24 * 60 * 60 * 1000;
+
+/** Read-buffer size for the synchronous spill readers. */
+const SPILL_READ_BUF_BYTES = 1 << 20;
+
+/** Bytes per f32 (vector-spill row stride is `dim * F32_BYTES`). */
+const F32_BYTES = 4;
+
 export interface IndexOptions {
   root: string;
   db: Connection;
   /** Where the manifest is written (the index directory). */
   indexDirPath: string;
-  /** Omit for a keyword-only index (vectors can be added by re-indexing). */
+  /** Omit for a keyword-only index (vectors can be added by re-indexing).
+   * The caller owns the embedder's lifecycle (dispose, when it has one). */
   embedder?: Embedder;
   caps?: IndexCaps;
   onPhase?: (phase: "scan" | "chunk" | "commit-text" | "embed" | "commit-vectors") => void;
@@ -90,7 +146,7 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
   // Keep the index out of the user's commits before we write a byte of it.
   ensureIndexIgnored(root, indexDirPath);
 
-  // --- scan + chunk ---------------------------------------------------------
+  // --- scan -----------------------------------------------------------------
   onPhase?.("scan");
   const walked = walkRepo(root).filter(
     (f) => shouldIndexFile(f.path) && f.size <= caps.maxFileBytes,
@@ -98,110 +154,389 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
   const taken = walked.slice(0, caps.maxFiles);
   const truncatedFiles = walked.length - taken.length;
 
+  // --- chunk → spill ----------------------------------------------------------
+  // The whole tree spools to the chunk spill before any table is touched, so
+  // the previous index serves queries all through the walk, and a failure
+  // here (full disk, racing deletes) costs nothing.
   onPhase?.("chunk");
-  const chunks: Chunk[] = [];
+  mkdirSync(indexDirPath, { recursive: true });
+  sweepStaleSpills(indexDirPath);
+  const spill = newSpill(indexDirPath);
   const languages: Record<string, number> = {};
   const fileState = emptyFileState();
   let files = 0;
-  for (let i = 0; i < taken.length; i++) {
-    let buf: Buffer;
+  let chunkCount = 0;
+  try {
+    const chunkWriter = guardedWriter(spill.chunksPath);
     try {
-      buf = readFileSync(join(root, taken[i].path));
-    } catch {
-      continue; // racing deletes are fine - index what's readable
-    }
-    // Every readable candidate is fingerprinted (binary ones too, so a later
-    // sync's stat walk doesn't keep rediscovering them as "added").
-    fileState.files[taken[i].path] = {
-      size: taken[i].size,
-      mtimeMs: taken[i].mtimeMs,
-      hash: hashContent(buf),
-    };
-    if (looksBinary(buf)) continue;
-    const fileChunks = await chunkFile(taken[i].path, buf.toString("utf8"));
-    if (fileChunks.length === 0) continue;
-    files++;
-    for (const c of fileChunks) languages[c.lang || "other"] = (languages[c.lang || "other"] ?? 0) + 1;
-    chunks.push(...fileChunks);
-    if (i % 50 === 0) onProgress?.(i, taken.length);
-  }
-
-  // --- stage 1: keyword index (search is live when this returns) -------------
-  onPhase?.("commit-text");
-  if (db.listTables().includes(TABLE)) db.dropTable(TABLE, true);
-  const textTable = db.createTable(TABLE, { ...TEXT_SCHEMA }, new IndexSpec().fts("content"));
-  for (let i = 0; i < chunks.length; i += APPEND_BATCH) {
-    textTable.append(chunks.slice(i, i + APPEND_BATCH).map(toTextRow));
-    onProgress?.(Math.min(i + APPEND_BATCH, chunks.length), chunks.length);
-  }
-  if (!embedder) compact(textTable);
-  const indexMs = Math.round(performance.now() - t0);
-
-  const stats: IndexStats = {
-    files,
-    chunks: chunks.length,
-    ...(truncatedFiles > 0 ? { truncatedFiles } : {}),
-    maxFiles: caps.maxFiles,
-    languages,
-    vectors: embedder ? "building" : "none",
-    indexMs,
-  };
-  writeManifest(indexDirPath, toManifest(stats));
-  writeFileState(indexDirPath, fileState);
-  if (!embedder) return { text: stats, completion: Promise.resolve(stats) };
-
-  // --- stage 2: embed + rebuild with a vector index ---------------------------
-  // A failure here (model download, endpoint down) leaves the keyword index
-  // live and the manifest honest - search degrades, indexing never fails.
-  const completion = (async () => {
-    try {
-      onPhase?.("embed");
-      const tEmbed = performance.now();
-      const dim = await embedder.dim();
-      const vectors: number[][] = [];
-      for (let i = 0; i < chunks.length; i += EMBED_BATCH) {
-        const batch = chunks.slice(i, i + EMBED_BATCH);
-        vectors.push(...(await embedder.embed(batch.map(embedText))));
-        onProgress?.(Math.min(i + EMBED_BATCH, chunks.length), chunks.length);
+      for (let i = 0; i < taken.length; i++) {
+        let buf: Buffer;
+        try {
+          buf = readFileSync(join(root, taken[i].path));
+        } catch {
+          continue; // racing deletes are fine - index what's readable
+        }
+        // Every readable candidate is fingerprinted (binary ones too, so a later
+        // sync's stat walk doesn't keep rediscovering them as "added").
+        fileState.files[taken[i].path] = {
+          size: taken[i].size,
+          mtimeMs: taken[i].mtimeMs,
+          hash: hashContent(buf),
+        };
+        if (looksBinary(buf)) continue;
+        const fileChunks = await chunkFile(taken[i].path, buf.toString("utf8"));
+        if (fileChunks.length === 0) continue;
+        files++;
+        chunkCount += fileChunks.length;
+        for (const c of fileChunks) {
+          languages[c.lang || "other"] = (languages[c.lang || "other"] ?? 0) + 1;
+          await chunkWriter.write(JSON.stringify(c) + "\n");
+        }
+        if (i % 50 === 0) onProgress?.(i, taken.length);
       }
+      await chunkWriter.close();
+    } catch (err) {
+      chunkWriter.destroy();
+      throw err;
+    }
+  } catch (err) {
+    spill.release(); // previous index untouched - just clean up and surface
+    throw err;
+  }
 
-      // The rebuild below is one synchronous block - drop, create, append  - 
-      // so concurrent readers in this process never observe a half-built table.
-      onPhase?.("commit-vectors");
-      db.dropTable(TABLE, true);
-      const hybridTable = db.createTable(
-        TABLE,
-        { ...TEXT_SCHEMA, embedding: { vector: dim } },
-        new IndexSpec().fts("content").vector("embedding", dim, N_CENT, "cosine"),
+  // --- stage 1: swap in the keyword table -------------------------------------
+  // One synchronous block (drop → create → append waves; sync spill reads, no
+  // awaits) so same-process readers never observe a half-swapped table. From
+  // here until the completion promise exists (whose finally owns the spill),
+  // any throw must release it - a leaked name would pin the file in the
+  // liveSpills registry for the life of the process.
+  try {
+    onPhase?.("commit-text");
+    if (db.listTables().includes(TABLE)) db.dropTable(TABLE, true);
+    const textTable = db.createTable(TABLE, { ...TEXT_SCHEMA }, new IndexSpec().fts("content"));
+    appendSpillSync(textTable, spill, chunkCount, undefined, onProgress);
+    if (!embedder) compact(textTable);
+    const indexMs = Math.round(performance.now() - t0);
+
+    const stats: IndexStats = {
+      files,
+      chunks: chunkCount,
+      ...(truncatedFiles > 0 ? { truncatedFiles } : {}),
+      maxFiles: caps.maxFiles,
+      languages,
+      vectors: embedder ? "building" : "none",
+      indexMs,
+    };
+    writeManifest(indexDirPath, toManifest(stats));
+    writeFileState(indexDirPath, fileState);
+    if (!embedder) {
+      spill.release();
+      return { text: stats, completion: Promise.resolve(stats) };
+    }
+
+    // --- stage 2: embed, then swap in the hybrid table -------------------------
+    // A failure anywhere before the swap (model download, endpoint down, full
+    // disk) leaves the stage-1 keyword table live and the manifest honest -
+    // search degrades, indexing never fails. The swap itself is again one
+    // synchronous block. `completion` must never reject; its finally owns the
+    // spill from here on.
+    const completion = (async () => {
+      try {
+        onPhase?.("embed");
+        const tEmbed = performance.now();
+        const dim =
+          chunkCount === 0
+            ? await embedder.dim() // no chunks to embed - just size the schema
+            : await embedSpill(spill, embedder, chunkCount, onProgress);
+
+        onPhase?.("commit-vectors");
+        db.dropTable(TABLE, true);
+        const hybridTable = db.createTable(
+          TABLE,
+          { ...TEXT_SCHEMA, embedding: { vector: dim } },
+          new IndexSpec().fts("content").vector("embedding", dim, N_CENT, "cosine"),
+        );
+        // Zero chunks ⇒ no vector spill was ever written; the empty table is
+        // already complete.
+        if (chunkCount > 0) appendSpillSync(hybridTable, spill, chunkCount, dim, onProgress);
+        compact(hybridTable);
+        stats.vectors = "ready";
+        stats.embedMs = Math.round(performance.now() - tEmbed);
+        writeManifest(
+          indexDirPath,
+          toManifest(stats, {
+            provider: embedder.provider,
+            model: embedder.model,
+            dim,
+            ...(embedder.dtype ? { dtype: embedder.dtype } : {}),
+          }),
+        );
+      } catch (err) {
+        stats.vectors = "none";
+        stats.embedError = (err as Error).message;
+        try {
+          writeManifest(indexDirPath, toManifest(stats));
+        } catch {
+          /* disk gone - nothing left to record on, and completion must not reject */
+        }
+      } finally {
+        spill.release();
+      }
+      return stats;
+    })();
+    return { text: { ...stats }, completion };
+  } catch (err) {
+    spill.release();
+    throw err;
+  }
+}
+
+// --- spill plumbing ------------------------------------------------------------
+
+interface Spill {
+  chunksPath: string;
+  vectorsPath: string;
+  /** Delete both files and drop them from the in-process live registry. */
+  release(): void;
+}
+
+/** Basenames of spills owned by in-flight builds in this process; the stale
+ * sweep never touches these. */
+const liveSpills = new Set<string>();
+let spillSeq = 0;
+
+function newSpill(indexDirPath: string): Spill {
+  const base = `${SPILL_OWNER}${++spillSeq}`;
+  const names = [`${base}.chunks.ndjson`, `${base}.vectors.f32`];
+  for (const n of names) liveSpills.add(n);
+  const [chunksPath, vectorsPath] = names.map((n) => join(indexDirPath, n));
+  return {
+    chunksPath,
+    vectorsPath,
+    release() {
+      for (const n of names) {
+        liveSpills.delete(n);
+        try {
+          rmSync(join(indexDirPath, n), { force: true });
+        } catch {
+          /* best-effort - the stale sweep on the next build gets another try */
+        }
+      }
+    },
+  };
+}
+
+/** Remove leftover spills from crashed builds: this process's own dead files
+ * immediately (anything not in the live registry), other processes' only
+ * once older than STALE_SPILL_MS - a young foreign spill may be a live
+ * backfill in another process. Best-effort. */
+function sweepStaleSpills(indexDirPath: string): void {
+  let names: string[];
+  try {
+    names = readdirSync(indexDirPath);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith(SPILL_PREFIX) || liveSpills.has(name)) continue;
+    try {
+      if (!name.startsWith(SPILL_OWNER) && Date.now() - statSync(join(indexDirPath, name)).mtimeMs < STALE_SPILL_MS) {
+        continue;
+      }
+      rmSync(join(indexDirPath, name), { force: true });
+    } catch {
+      /* raced another cleanup - fine */
+    }
+  }
+}
+
+/** A WriteStream wrapper that records async 'error' events and surfaces them
+ * at the next write/close instead of crashing the process (an fs.WriteStream
+ * 'error' with no listener is FATAL to Node, and most of a spill's lifetime
+ * is spent awaiting the embedder, not awaiting stream events). */
+function guardedWriter(path: string) {
+  const stream: WriteStream = createWriteStream(path);
+  let failure: Error | null = null;
+  stream.on("error", (err) => {
+    failure = err as Error;
+  });
+  return {
+    async write(data: string | Buffer): Promise<void> {
+      if (failure) throw failure;
+      if (!stream.write(data)) {
+        await once(stream, "drain"); // rejects if 'error' fires while waiting
+      }
+    },
+    async close(): Promise<void> {
+      if (failure) throw failure;
+      stream.end();
+      await once(stream, "close");
+      if (failure) throw failure;
+    },
+    destroy(): void {
+      stream.destroy();
+    },
+  };
+}
+
+/** Fully synchronous line iterator over an NDJSON spill (StringDecoder keeps
+ * multi-byte UTF-8 intact across buffer boundaries). Sync on purpose: it runs
+ * inside the atomic drop→create→append blocks, which must not await. */
+function* readLinesSync(path: string): Generator<string> {
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.allocUnsafe(SPILL_READ_BUF_BYTES);
+    const decoder = new StringDecoder("utf8");
+    let carry = "";
+    for (;;) {
+      const n = readSync(fd, buf, 0, buf.length, null);
+      if (n === 0) break;
+      carry += decoder.write(buf.subarray(0, n));
+      let nl: number;
+      while ((nl = carry.indexOf("\n")) >= 0) {
+        yield carry.slice(0, nl);
+        carry = carry.slice(nl + 1);
+      }
+    }
+    carry += decoder.end();
+    if (carry.length > 0) yield carry;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Replay a spill into a table in APPEND_BATCH waves - synchronously, so the
+ * caller's drop→create→append block stays atomic to same-process readers.
+ * With `dim` set, each row is joined with its packed f32 vector from the
+ * vector spill (same order, same count - verified, since a silently short
+ * table is the one unrecoverable outcome). Only the in-flight wave is ever
+ * resident; the engine binding takes number[] rows, so one wave is boxed
+ * transiently - bounded, unlike the whole-corpus number[][] this replaces. */
+function appendSpillSync(
+  table: { append(rows: RowRecord[]): void },
+  spill: Spill,
+  expectedRows: number,
+  dim?: number,
+  onProgress?: (done: number, total: number) => void,
+): void {
+  const rows: Chunk[] = [];
+  let appended = 0;
+  let fd = -1;
+  if (dim !== undefined) {
+    fd = openSync(spill.vectorsPath, "r");
+    const size = fstatSync(fd).size;
+    if (size !== expectedRows * dim * F32_BYTES) {
+      closeSync(fd);
+      throw new Error(
+        `vector spill holds ${size} bytes, expected ${expectedRows * dim * F32_BYTES} (${expectedRows} rows × ${dim}d)`,
       );
-      for (let i = 0; i < chunks.length; i += APPEND_BATCH) {
-        hybridTable.append(
-          chunks.slice(i, i + APPEND_BATCH).map((c, j) => ({
+    }
+  }
+  try {
+    const appendWave = () => {
+      if (rows.length === 0) return;
+      if (dim === undefined) {
+        table.append(rows.map(toTextRow));
+      } else {
+        const want = rows.length * dim * F32_BYTES;
+        // Own ArrayBuffer (not the pooled Buffer.alloc) so the f32 view is
+        // 4-byte aligned regardless of wave size.
+        const ab = new ArrayBuffer(want);
+        const buf = Buffer.from(ab);
+        let got = 0;
+        while (got < want) {
+          const n = readSync(fd, buf, got, want - got, null);
+          if (n === 0) throw new Error(`vector spill truncated (wanted ${want} more bytes)`);
+          got += n;
+        }
+        const f32 = new Float32Array(ab);
+        table.append(
+          rows.map((c, j) => ({
             ...toTextRow(c),
-            embedding: vectors[i + j],
+            embedding: Array.from(f32.subarray(j * dim, (j + 1) * dim)),
           })),
         );
       }
-      compact(hybridTable);
-      stats.vectors = "ready";
-      stats.embedMs = Math.round(performance.now() - tEmbed);
-      writeManifest(
-        indexDirPath,
-        toManifest(stats, {
-          provider: embedder.provider,
-          model: embedder.model,
-          dim,
-          ...(embedder.dtype ? { dtype: embedder.dtype } : {}),
-        }),
-      );
-    } catch (err) {
-      stats.vectors = "none";
-      stats.embedError = (err as Error).message;
-      writeManifest(indexDirPath, toManifest(stats));
+      appended += rows.length;
+      rows.length = 0;
+      onProgress?.(appended, expectedRows);
+    };
+    for (const line of readLinesSync(spill.chunksPath)) {
+      rows.push(JSON.parse(line) as Chunk);
+      if (rows.length >= APPEND_BATCH) appendWave();
     }
-    return stats;
-  })();
-  return { text: { ...stats }, completion };
+    appendWave();
+    if (appended !== expectedRows) {
+      throw new Error(`chunk spill replayed ${appended} rows, expected ${expectedRows}`);
+    }
+  } finally {
+    if (fd >= 0) closeSync(fd);
+  }
+}
+
+/** Stream the chunk spill through the embedder in EMBED_BATCH waves, packing
+ * f32 rows into the vector spill. Async is fine here: the previous table is
+ * still serving queries. Returns the vector dimension; throws on a dim change
+ * or count mismatch (before anything is dropped). */
+async function embedSpill(
+  spill: Spill,
+  embedder: Embedder,
+  total: number,
+  onProgress?: (done: number, total: number) => void,
+): Promise<number> {
+  const out = guardedWriter(spill.vectorsPath);
+  try {
+    let dim: number | undefined;
+    let done = 0;
+    const batch: Chunk[] = [];
+
+    const embedBatch = async () => {
+      if (batch.length === 0) return;
+      const texts = batch.map(embedText);
+      let vectors: Float32Array;
+      let d: number;
+      if (embedder.embedToFloat32) {
+        ({ vectors, dim: d } = await embedder.embedToFloat32(texts));
+      } else {
+        const rows = await embedder.embed(texts);
+        d = rows[0]?.length ?? 0;
+        vectors = Float32Array.from(rows.flat());
+      }
+      if (d <= 0 || vectors.length !== batch.length * d) {
+        throw new Error(`embedder returned ${vectors.length} floats for ${batch.length} texts (dim ${d})`);
+      }
+      if (dim === undefined) dim = d;
+      else if (dim !== d) throw new Error(`embedding dim changed mid-run: ${dim} → ${d}`);
+      await out.write(Buffer.from(vectors.buffer, vectors.byteOffset, vectors.byteLength));
+      done += batch.length;
+      batch.length = 0;
+      onProgress?.(Math.min(done, total), total);
+      // Keep the chunk spill's mtime fresh: another process's stale sweep
+      // judges foreign spills by age, and the chunk file goes cold the moment
+      // the walk ends while this embed phase can run for hours.
+      try {
+        const now = new Date();
+        utimesSync(spill.chunksPath, now, now);
+      } catch {
+        /* best-effort */
+      }
+    };
+
+    const lines = createInterface({ input: createReadStream(spill.chunksPath) });
+    for await (const line of lines) {
+      batch.push(JSON.parse(line) as Chunk);
+      if (batch.length >= EMBED_BATCH) await embedBatch();
+    }
+    await embedBatch();
+    await out.close();
+    if (done !== total || dim === undefined) {
+      throw new Error(`embedding count mismatch: ${done} vectors for ${total} chunks`);
+    }
+    return dim;
+  } catch (err) {
+    out.destroy();
+    throw err;
+  }
 }
 
 // --- incremental sync --------------------------------------------------------
@@ -229,7 +564,9 @@ export type SyncOutcome = SyncResult | { action: "rebuild-required"; reason: str
  * re-embedding) only the files that changed since the last index or sync.
  * Reports `rebuild-required` instead of guessing when incremental can't be
  * correct (no prior state, an in-flight vector backfill, or an embedder that
- * no longer matches the index). */
+ * no longer matches the index). Fresh chunks spool through spills and are
+ * embedded BEFORE any stale row is deleted, so an embed failure (which throws)
+ * leaves the index exactly as it was. */
 export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
   const { root, db, indexDirPath, embedder, onPhase } = opts;
   const caps = opts.caps ?? DEFAULT_CAPS;
@@ -259,12 +596,12 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
   const walked = walkRepo(root).filter((f) => shouldIndexFile(f.path) && f.size <= caps.maxFileBytes);
   const candidates = walked.slice(0, caps.maxFiles);
   const truncatedFiles = walked.length - candidates.length;
-  const buffers = new Map<string, Buffer>();
+  // Content is re-read at chunk time rather than cached here: a branch switch
+  // can change thousands of files, and holding every changed buffer is
+  // exactly the whole-repo materialization this module avoids.
   const diff = diffFiles(candidates, prev, (path) => {
     try {
-      const buf = readFileSync(join(root, path));
-      buffers.set(path, buf);
-      return buf;
+      return readFileSync(join(root, path));
     } catch {
       return undefined;
     }
@@ -302,91 +639,107 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
     };
   }
 
-  // --- re-chunk (and re-embed) just the touched files ---------------------------
+  // --- chunk the touched files into a spill --------------------------------------
   onPhase?.("chunk");
-  const freshChunks: Chunk[] = [];
-  for (const path of [...diff.added, ...diff.changed]) {
-    const buf = buffers.get(path);
-    if (!buf || looksBinary(buf)) continue;
-    freshChunks.push(...(await chunkFile(path, buf.toString("utf8"))));
-  }
-
-  let vectors: number[][] | undefined;
-  if (hasVectors && embedder && freshChunks.length > 0) {
-    onPhase?.("embed");
-    vectors = [];
-    for (let i = 0; i < freshChunks.length; i += EMBED_BATCH) {
-      const batch = freshChunks.slice(i, i + EMBED_BATCH);
-      vectors.push(...(await embedder.embed(batch.map(embedText))));
-      opts.onProgress?.(Math.min(i + EMBED_BATCH, freshChunks.length), freshChunks.length);
+  sweepStaleSpills(indexDirPath);
+  const spill = newSpill(indexDirPath);
+  try {
+    let chunksAdded = 0;
+    const chunkWriter = guardedWriter(spill.chunksPath);
+    try {
+      for (const path of [...diff.added, ...diff.changed]) {
+        let buf: Buffer;
+        try {
+          buf = readFileSync(join(root, path));
+        } catch {
+          // Readable at diff time, gone now. Drop it from the recorded state so
+          // the next sync re-examines it instead of treating it as indexed -
+          // its stale rows are deleted below either way.
+          delete diff.next.files[path];
+          continue;
+        }
+        if (looksBinary(buf)) continue;
+        for (const c of await chunkFile(path, buf.toString("utf8"))) {
+          chunksAdded++;
+          await chunkWriter.write(JSON.stringify(c) + "\n");
+        }
+      }
+      await chunkWriter.close();
+    } catch (err) {
+      chunkWriter.destroy();
+      throw err;
     }
-  }
 
-  // --- apply: delete stale rows, append fresh ones ------------------------------
-  onPhase?.("commit-text");
-  const table = db.openTable(TABLE);
-  // `added` paths are deleted too: it makes a re-run of an interrupted sync
-  // idempotent instead of duplicating rows.
-  const stale = [...diff.added, ...diff.changed, ...diff.deleted];
-  let chunksRemoved = 0;
-  for (let i = 0; i < stale.length; i += 100) {
-    const batch = stale.slice(i, i + 100).map((p) => `'${p.replace(/'/g, "''")}'`);
-    chunksRemoved += table.delete(`path IN (${batch.join(",")})`).nTombstoned;
-  }
-  for (let i = 0; i < freshChunks.length; i += APPEND_BATCH) {
-    table.append(
-      freshChunks.slice(i, i + APPEND_BATCH).map((c, j) => ({
-        ...toTextRow(c),
-        ...(vectors ? { embedding: vectors[i + j] } : {}),
-      })),
-    );
-  }
+    // --- embed them (before ANY delete - a throw here must cost nothing) --------
+    let dim: number | undefined;
+    if (hasVectors && embedder && chunksAdded > 0) {
+      onPhase?.("embed");
+      dim = await embedSpill(spill, embedder, chunksAdded, opts.onProgress);
+    }
 
-  // --- persist state + recount ----------------------------------------------------
-  writeFileState(indexDirPath, diff.next);
-  const [{ n: chunkCount, f: fileCount }] = db.querySql(
-    `SELECT COUNT(*) AS n, COUNT(DISTINCT path) AS f FROM ${TABLE}`,
-  ) as [{ n: unknown; f: unknown }];
-  const langRows = db.querySql(
-    `SELECT lang, COUNT(*) AS n FROM ${TABLE} GROUP BY lang`,
-  ) as Array<{ lang: string; n: unknown }>;
-  const languages: Record<string, number> = {};
-  for (const r of langRows) languages[r.lang || "other"] = Number(r.n);
-  const nextManifest: Manifest = {
-    ...manifest,
-    files: Number(fileCount),
-    chunks: Number(chunkCount),
-    languages,
-    indexedAt: new Date().toISOString(),
-  };
-  // Track truncation as the tree grows or shrinks: set the fields when files
-  // are now over the cap, clear the stale ones (spread from `manifest`) when
-  // the tree has dropped back under it.
-  if (truncatedFiles > 0) {
-    nextManifest.truncatedFiles = truncatedFiles;
-    nextManifest.maxFiles = caps.maxFiles;
-  } else {
-    delete nextManifest.truncatedFiles;
-    delete nextManifest.maxFiles;
+    // --- apply: one synchronous block of deletes + appends -------------------------
+    onPhase?.("commit-text");
+    const table = db.openTable(TABLE);
+    // `added` paths are deleted too: it makes a re-run of an interrupted sync
+    // idempotent instead of duplicating rows.
+    const stale = [...diff.added, ...diff.changed, ...diff.deleted];
+    let chunksRemoved = 0;
+    for (let i = 0; i < stale.length; i += 100) {
+      const batch = stale.slice(i, i + 100).map((p) => `'${p.replace(/'/g, "''")}'`);
+      chunksRemoved += table.delete(`path IN (${batch.join(",")})`).nTombstoned;
+    }
+    if (chunksAdded > 0) {
+      appendSpillSync(table, spill, chunksAdded, hasVectors && embedder ? dim : undefined);
+    }
+
+    // --- persist state + recount ----------------------------------------------------
+    writeFileState(indexDirPath, diff.next);
+    const [{ n: chunkCount, f: fileCount }] = db.querySql(
+      `SELECT COUNT(*) AS n, COUNT(DISTINCT path) AS f FROM ${TABLE}`,
+    ) as [{ n: unknown; f: unknown }];
+    const langRows = db.querySql(
+      `SELECT lang, COUNT(*) AS n FROM ${TABLE} GROUP BY lang`,
+    ) as Array<{ lang: string; n: unknown }>;
+    const languages: Record<string, number> = {};
+    for (const r of langRows) languages[r.lang || "other"] = Number(r.n);
+    const nextManifest: Manifest = {
+      ...manifest,
+      files: Number(fileCount),
+      chunks: Number(chunkCount),
+      languages,
+      indexedAt: new Date().toISOString(),
+    };
+    // Track truncation as the tree grows or shrinks: set the fields when files
+    // are now over the cap, clear the stale ones (spread from `manifest`) when
+    // the tree has dropped back under it.
+    if (truncatedFiles > 0) {
+      nextManifest.truncatedFiles = truncatedFiles;
+      nextManifest.maxFiles = caps.maxFiles;
+    } else {
+      delete nextManifest.truncatedFiles;
+      delete nextManifest.maxFiles;
+    }
+    writeManifest(indexDirPath, nextManifest);
+
+    // --- compact after deletes/appends to keep tombstones clean ---
+    compact(table);
+
+    return {
+      action: "synced",
+      filesAdded: diff.added.length,
+      filesChanged: diff.changed.length,
+      filesDeleted: diff.deleted.length,
+      chunksAdded,
+      chunksRemoved,
+      files: nextManifest.files,
+      chunks: nextManifest.chunks,
+      truncatedFiles,
+      vectors: nextManifest.vectors,
+      tookMs: Math.round(performance.now() - t0),
+    };
+  } finally {
+    spill.release();
   }
-  writeManifest(indexDirPath, nextManifest);
-
-  // --- compact after deletes/appends to keep tombstones clean ---
-  compact(table);
-
-  return {
-    action: "synced",
-    filesAdded: diff.added.length,
-    filesChanged: diff.changed.length,
-    filesDeleted: diff.deleted.length,
-    chunksAdded: freshChunks.length,
-    chunksRemoved,
-    files: nextManifest.files,
-    chunks: nextManifest.chunks,
-    truncatedFiles,
-    vectors: nextManifest.vectors,
-    tookMs: Math.round(performance.now() - t0),
-  };
 }
 
 /** Post-build/sync compaction: batched appends leave many small superfiles behind

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -591,6 +591,12 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
     };
   }
 
+  // Sweep crash leftovers on every sync, INCLUDING ones about to no-op: on an
+  // unchanging repo the no-op path is the only code that ever runs again, and
+  // a crashed build's spill would otherwise sit in the index dir forever.
+  // One readdir, throttled upstream by the auto-sync interval.
+  sweepStaleSpills(indexDirPath);
+
   // --- diff -------------------------------------------------------------------
   onPhase?.("scan");
   const walked = walkRepo(root).filter((f) => shouldIndexFile(f.path) && f.size <= caps.maxFileBytes);
@@ -641,7 +647,6 @@ export async function syncRepo(opts: IndexOptions): Promise<SyncOutcome> {
 
   // --- chunk the touched files into a spill --------------------------------------
   onPhase?.("chunk");
-  sweepStaleSpills(indexDirPath);
   const spill = newSpill(indexDirPath);
   try {
     let chunksAdded = 0;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,8 +24,14 @@ import { readManifest, type Manifest } from "../core/manifest.js";
 import type { IndexHandle } from "../core/context.js";
 import { search, runSql, jsonify, partialIndex } from "../core/searcher.js";
 import { newSession, receiptEnabled, searchEntry, sqlEntry, formatReceipt, recordUsage } from "../core/usage.js";
-import { indexRepoStaged, syncRepo, type SyncOutcome, type IndexStats } from "../core/indexer.js";
-import { createEmbedder, embedderInfo, type Embedder } from "../core/embedder.js";
+import {
+  indexRepoStaged,
+  syncRepo,
+  type SyncOutcome,
+  type IndexStats,
+  type StagedIndexRun,
+} from "../core/indexer.js";
+import { createEmbedder, createIndexingEmbedder, embedderInfo, type Embedder } from "../core/embedder.js";
 import { RepoRegistry, type RepoCtx } from "./repos.js";
 import { ensureIndexed, type EnsureResult } from "./ensure.js";
 
@@ -80,18 +86,34 @@ export async function serveMcp(rootPath?: string): Promise<void> {
     return p;
   };
 
+  /** Fresh build-scoped embedder: full builds embed in a child process so the
+   * bulk pipeline's memory leaves with it (issue #9). Query and sync
+   * embedding keep the warm in-process singleton via getEmbedder(). */
+  const buildEmbedder = () => (process.env.CX_NO_EMBED ? undefined : createIndexingEmbedder());
+
+  /** Let vectors backfill in-process (the manifest flips to "ready"), then
+   * release the build's embedder. `completion` never rejects by contract, but
+   * nothing on this chain may take that on faith - an unhandled rejection
+   * here would kill the whole server. */
+  const backfill = (run: StagedIndexRun, emb: Embedder | undefined) => {
+    void run.completion
+      .catch(() => undefined)
+      .finally(() => void emb?.dispose?.()?.catch(() => undefined));
+  };
+
   /** Acquire the repo's mutation lock and run a staged build; resolves at
    * keyword-live with stage-1 stats, or null if a build is already in flight. */
   const buildIndex = (ctx: RepoCtx): Promise<IndexStats> | null =>
     exclusive(ctx, async () => {
+      const emb = buildEmbedder();
       const run = await indexRepoStaged({
         root: ctx.root,
         db: ctx.db,
         indexDirPath: ctx.dir,
-        embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
+        embedder: emb,
         caps: DEFAULT_CAPS,
       });
-      void run.completion; // vectors backfill in-process; manifest flips to "ready"
+      backfill(run, emb);
       return run.text;
     });
 
@@ -104,14 +126,15 @@ export async function serveMcp(rootPath?: string): Promise<void> {
       caps: DEFAULT_CAPS,
     });
     if (outcome.action === "rebuild-required" && outcome.reason !== "vector backfill in progress") {
+      const emb = buildEmbedder();
       const run = await indexRepoStaged({
         root: ctx.root,
         db: ctx.db,
         indexDirPath: ctx.dir,
-        embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
+        embedder: emb,
         caps: DEFAULT_CAPS,
       });
-      void run.completion;
+      backfill(run, emb);
     }
     return outcome;
   };
@@ -360,14 +383,15 @@ export async function serveMcp(rootPath?: string): Promise<void> {
       }
       try {
         const runFull = async () => {
+          const emb = buildEmbedder();
           const run = await indexRepoStaged({
             root: ctx.root,
             db: ctx.db,
             indexDirPath: ctx.dir,
-            embedder: process.env.CX_NO_EMBED ? undefined : getEmbedder(),
+            embedder: emb,
             caps: DEFAULT_CAPS,
           });
-          void run.completion; // backfills in-process; manifest flips to "ready"
+          backfill(run, emb);
           return ok({ status: "rebuilt - keyword search live; vectors backfilling", ...run.text });
         };
         const result = exclusive(ctx, async () => {

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -6,7 +6,7 @@
 // the on-disk spills - and the spills must vanish when the vector stage
 // settles, success or failure. Fixtures are sized past APPEND_BATCH so the
 // multi-wave paths actually run; fake embedders keep CI off the network.
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -270,6 +270,28 @@ describe("review-confirmed regressions", () => {
     expect(outcome.action).toBe("synced");
     expect(phases).toEqual(["scan", "chunk", "embed", "commit-text"]);
     expect(progressed).toBeGreaterThan(0);
+  });
+});
+
+describe("crash-leftover spills on a quiet repo", () => {
+  it("a no-op sync sweeps stale foreign spills but spares young ones", async () => {
+    await indexRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+
+    // Leftovers from a "crashed" foreign process: same layout, alien pid-token.
+    const stale = join(dir, "spill.99999-deadbe.1.chunks.ndjson");
+    const young = join(dir, "spill.99999-deadbe.2.chunks.ndjson");
+    writeFileSync(stale, '{"fake":1}\n');
+    writeFileSync(young, '{"fake":1}\n');
+    const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    utimesSync(stale, dayAgo, dayAgo);
+
+    const outcome = await syncRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+    expect(outcome.action).toBe("noop");
+    // The >24h leftover is reclaimed even though nothing changed in the tree;
+    // the young file survives - it may be another process's live backfill.
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(young)).toBe(true);
+    rmSync(young, { force: true });
   });
 });
 

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Streaming-index regressions (issue #9): builds and syncs must hold only
+// bounded batches - stage 1 interleaves chunk→append, stage 2 goes through
+// the on-disk spills - and the spills must vanish when the vector stage
+// settles, success or failure. Fixtures are sized past APPEND_BATCH so the
+// multi-wave paths actually run; fake embedders keep CI off the network.
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { connect, type Connection } from "@infino-ai/infino";
+import { APPEND_BATCH, EMBED_BATCH } from "../src/core/config.js";
+import { indexRepo, indexRepoStaged, syncRepo, type SyncResult } from "../src/core/indexer.js";
+import { readManifest } from "../src/core/manifest.js";
+import { search } from "../src/core/searcher.js";
+import { unpackRows, type Embedder } from "../src/core/embedder.js";
+import type { IndexHandle } from "../src/core/context.js";
+
+const DIM = 16; // engine minimum
+
+/** Deterministic vector for a text (same math as the other suites' fakes). */
+function vectorFor(t: string): number[] {
+  const v = new Array<number>(DIM).fill(0.01);
+  for (let i = 0; i < t.length; i++) v[i % DIM] += t.charCodeAt(i) / 1000;
+  return v;
+}
+
+/** Fake that only implements embed() - the compatibility path. */
+const embedOnlyFake: Embedder = {
+  embed: async (texts) => texts.map(vectorFor),
+  dim: async () => DIM,
+  provider: "fake",
+  model: "fake-16d",
+};
+
+/** Fake that also implements embedToFloat32() - the streaming fast path. */
+const float32Fake: Embedder = {
+  ...embedOnlyFake,
+  embedToFloat32: async (texts) => {
+    const vectors = new Float32Array(texts.length * DIM);
+    texts.forEach((t, i) => vectors.set(vectorFor(t), i * DIM));
+    return { vectors, dim: DIM };
+  },
+};
+
+/** Enough .js files that total chunks cross APPEND_BATCH, so the interleaved
+ * append loop and the spill replay both run multi-wave. Each file carries one
+ * distinctive token so hits are attributable. */
+function writeBigFixture(root: string, nFiles: number): void {
+  mkdirSync(join(root, "src"), { recursive: true });
+  for (let f = 0; f < nFiles; f++) {
+    const lines: string[] = [`// module ${f}: streamingfixture${f}`];
+    for (let fn = 0; fn < 40; fn++) {
+      lines.push(`export function handler${f}x${fn}(input) {`);
+      for (let body = 0; body < 58; body++) {
+        lines.push(`  input = input + ${body}; // step ${body} of pipeline ${f}.${fn}`);
+      }
+      lines.push(`  return input;`, `}`);
+    }
+    writeFileSync(join(root, "src", `mod${f}.js`), lines.join("\n") + "\n");
+  }
+}
+
+function spillNames(dir: string): string[] {
+  return existsSync(dir) ? readdirSync(dir).filter((f) => f.startsWith("spill.")) : [];
+}
+
+let root: string;
+let dir: string;
+let db: Connection;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "cx-stream-"));
+  dir = join(root, ".infino");
+  writeBigFixture(root, 14);
+  db = connect(dir);
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("streamed staged build", () => {
+  it("crosses APPEND_BATCH, lands hybrid search, and cleans its spills", async () => {
+    const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+    expect(stats.vectors).toBe("ready");
+    expect(stats.chunks).toBeGreaterThan(APPEND_BATCH);
+
+    // Every spilled row made it into the rebuilt table.
+    const [{ n }] = db.querySql(`SELECT COUNT(*) AS n FROM chunks`) as [{ n: unknown }];
+    expect(Number(n)).toBe(stats.chunks);
+
+    const handle: IndexHandle = { root, dir, db, manifest: readManifest(dir)! };
+    const r = await search(handle, float32Fake, "streamingfixture3 pipeline", 5);
+    expect(r.ranking).toBe("hybrid");
+    expect(r.hits.length).toBeGreaterThan(0);
+
+    // Handoff files are gone once the vector stage settles.
+    expect(spillNames(dir)).toEqual([]);
+  });
+
+  it("builds through embed() alone when embedToFloat32 is absent", async () => {
+    const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: embedOnlyFake });
+    expect(stats.vectors).toBe("ready");
+    expect(stats.embedError).toBeUndefined();
+    expect(spillNames(dir)).toEqual([]);
+  });
+
+  it("keeps keyword search live and cleans spills when the model fails", async () => {
+    const broken: Embedder = {
+      ...embedOnlyFake,
+      embed: async () => {
+        throw new Error("model download failed");
+      },
+      embedToFloat32: undefined,
+      dim: async () => {
+        throw new Error("model download failed");
+      },
+    };
+    const run = await indexRepoStaged({ root, db, indexDirPath: dir, embedder: broken });
+    expect(run.text.vectors).toBe("building");
+    const final = await run.completion;
+    expect(final.vectors).toBe("none");
+    expect(final.embedError).toContain("model download failed");
+
+    // Keyword search still answers from the stage-1 table.
+    const handle: IndexHandle = { root, dir, db, manifest: readManifest(dir)! };
+    const r = await search(handle, embedOnlyFake, "streamingfixture5", 3);
+    expect(r.ranking).toBe("keyword");
+    expect(r.hits.length).toBeGreaterThan(0);
+    expect(spillNames(dir)).toEqual([]);
+  });
+
+  it("refuses a short embedding stream instead of building a silently short table", async () => {
+    // Drops one vector per batch: a truncated stream must surface as
+    // embedError, never as a table that quietly lost rows.
+    const short: Embedder = {
+      ...embedOnlyFake,
+      embedToFloat32: async (texts) => {
+        const kept = Math.max(texts.length - 1, 0);
+        const vectors = new Float32Array(kept * DIM);
+        texts.slice(0, kept).forEach((t, i) => vectors.set(vectorFor(t), i * DIM));
+        return { vectors, dim: DIM };
+      },
+    };
+    const run = await indexRepoStaged({ root, db, indexDirPath: dir, embedder: short });
+    const final = await run.completion;
+    expect(final.vectors).toBe("none");
+    expect(final.embedError).toMatch(/floats|mismatch/);
+    expect(spillNames(dir)).toEqual([]);
+  });
+});
+
+describe("streamed incremental sync", () => {
+  it("re-embeds a multi-wave changeset in bounded batches", async () => {
+    // Rebuild to a clean hybrid state, then grow the tree by several files
+    // whose chunks cross EMBED_BATCH several times over.
+    const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+    expect(stats.vectors).toBe("ready");
+
+    const added = 3;
+    for (let f = 100; f < 100 + added; f++) {
+      const lines: string[] = [`// module ${f}: syncwavefixture${f}`];
+      for (let fn = 0; fn < 40; fn++) {
+        lines.push(`export function later${f}x${fn}(x) {`);
+        for (let body = 0; body < 58; body++) lines.push(`  x += ${body}; // sync step`);
+        lines.push(`  return x;`, `}`);
+      }
+      writeFileSync(join(root, "src", `mod${f}.js`), lines.join("\n") + "\n");
+    }
+
+    const outcome = (await syncRepo({ root, db, indexDirPath: dir, embedder: float32Fake })) as SyncResult;
+    expect(outcome.action).toBe("synced");
+    expect(outcome.filesAdded).toBe(added);
+    expect(outcome.chunksAdded).toBeGreaterThan(EMBED_BATCH * 3);
+    expect(outcome.chunks).toBe(stats.chunks + outcome.chunksAdded);
+
+    const handle: IndexHandle = { root, dir, db, manifest: readManifest(dir)! };
+    const r = await search(handle, float32Fake, "syncwavefixture101", 3);
+    expect(r.ranking).toBe("hybrid");
+    expect(r.hits.some((h) => h.path === "src/mod101.js")).toBe(true);
+  });
+});
+
+describe("review-confirmed regressions", () => {
+  it("indexes an empty corpus to vectors:ready, not a spurious spill error", async () => {
+    const emptyRoot = mkdtempSync(join(tmpdir(), "cx-empty-"));
+    const emptyDir = join(emptyRoot, ".infino");
+    // One binary file: walked, fingerprinted, but yields zero chunks.
+    writeFileSync(join(emptyRoot, "blob.js"), Buffer.from([0, 1, 2, 0, 3]));
+    const emptyDb = connect(emptyDir);
+    try {
+      const stats = await indexRepo({ root: emptyRoot, db: emptyDb, indexDirPath: emptyDir, embedder: float32Fake });
+      expect(stats.chunks).toBe(0);
+      expect(stats.embedError).toBeUndefined();
+      expect(stats.vectors).toBe("ready");
+      expect(spillNames(emptyDir)).toEqual([]);
+    } finally {
+      rmSync(emptyRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("survives overlapping staged builds: separate spills, both end ready", async () => {
+    // A slow embedder holds build A in its vector stage while build B runs
+    // start to finish - the exact overlap a reindex(full) during backfill
+    // produces. With per-build spills neither may ENOENT the other.
+    const slow: Embedder = {
+      ...float32Fake,
+      embedToFloat32: async (texts) => {
+        await new Promise((r) => setTimeout(r, 20));
+        return float32Fake.embedToFloat32!(texts);
+      },
+    };
+    const runA = await indexRepoStaged({ root, db, indexDirPath: dir, embedder: slow });
+    const runB = await indexRepoStaged({ root, db, indexDirPath: dir, embedder: float32Fake });
+    const [a, b] = await Promise.all([runA.completion, runB.completion]);
+    expect(a.embedError).toBeUndefined();
+    expect(b.embedError).toBeUndefined();
+    expect(a.vectors).toBe("ready");
+    expect(b.vectors).toBe("ready");
+    // Whichever build won, the table is complete and consistent.
+    const [{ n }] = db.querySql(`SELECT COUNT(*) AS n FROM chunks`) as [{ n: unknown }];
+    expect(Number(n)).toBe(a.chunks);
+    expect(spillNames(dir)).toEqual([]);
+  });
+
+  it("sync embeds before deleting: an embed failure leaves the index intact", async () => {
+    const stats = await indexRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+    expect(stats.vectors).toBe("ready");
+    const [{ n: before }] = db.querySql(`SELECT COUNT(*) AS n FROM chunks`) as [{ n: unknown }];
+
+    writeFileSync(join(root, "src", "mod0.js"), "export function replacement() { return 1; }\n");
+    const failing: Embedder = {
+      ...embedOnlyFake,
+      embed: async () => {
+        throw new Error("endpoint down");
+      },
+    };
+    await expect(syncRepo({ root, db, indexDirPath: dir, embedder: failing })).rejects.toThrow("endpoint down");
+
+    // Nothing was deleted or appended; the old rows still serve hybrid search.
+    const [{ n: after }] = db.querySql(`SELECT COUNT(*) AS n FROM chunks`) as [{ n: unknown }];
+    expect(Number(after)).toBe(Number(before));
+    const handle: IndexHandle = { root, dir, db, manifest: readManifest(dir)! };
+    const r = await search(handle, float32Fake, "streamingfixture0 pipeline", 3);
+    expect(r.hits.some((h) => h.path === "src/mod0.js")).toBe(true);
+    expect(spillNames(dir)).toEqual([]);
+
+    // A later sync with a healthy embedder heals the same changeset.
+    const outcome = (await syncRepo({ root, db, indexDirPath: dir, embedder: float32Fake })) as SyncResult;
+    expect(outcome.action).toBe("synced");
+    expect(outcome.filesChanged).toBe(1);
+  });
+
+  it("sync reports phases in the pre-streaming order with embed progress", async () => {
+    await indexRepo({ root, db, indexDirPath: dir, embedder: float32Fake });
+    writeFileSync(join(root, "src", "mod1.js"), "export function phasedProbe() { return 2; }\n");
+    const phases: string[] = [];
+    let progressed = 0;
+    const outcome = await syncRepo({
+      root,
+      db,
+      indexDirPath: dir,
+      embedder: float32Fake,
+      onPhase: (p) => phases.push(p),
+      onProgress: () => progressed++,
+    });
+    expect(outcome.action).toBe("synced");
+    expect(phases).toEqual(["scan", "chunk", "embed", "commit-text"]);
+    expect(progressed).toBeGreaterThan(0);
+  });
+});
+
+describe("unpackRows", () => {
+  it("splits a packed row-major array into per-row number[]s", () => {
+    const packed = Float32Array.from([1, 2, 3, 4, 5, 6]);
+    expect(unpackRows(packed, 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    expect(unpackRows(new Float32Array(0), 3)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #9 

## Problem

Indexing a ~370-file repo held 2.34 GB resident, forever: stage 1 accumulated
every chunk in an array, stage 2 materialized every embedding as boxed
`number[][]` and rebuilt the table from those arrays, and the transformers.js
pipeline stayed resident as a module singleton with ONNX arenas that grow and
never shrink.

## Design

Same fill → append → discard shape the infino bench uses to stream corpora it
never materializes:

- **Spool, then swap.** Chunks stream to a per-build NDJSON spill during the
  walk while the previous table keeps serving queries untouched. Every
  drop → create → append swap replays the spill in `APPEND_BATCH` waves inside
  **one synchronous block** (sync spill readers, no awaits), so same-process
  readers never observe a half-swapped table — the same atomicity the
  pre-streaming code had.
- **Embed in a short-lived child.** Stage 2 streams the chunk spill through an
  `embed-worker` child process (lockstep NDJSON-over-stdio, packed f32 rows as
  base64, `@cx:`-prefixed protocol lines, 15m cold / 10m warm reply deadlines,
  `CX_EMBED_WORKER_TIMEOUT_MS` to raise) into a packed-f32 vector spill, then
  swaps. The child exits when the vector stage settles, returning the ONNX
  arenas to the OS. Query-time embedding keeps the warm in-process pipeline
  (one short string per call).
- **Sync embeds before it deletes.** An embed failure throws before a single
  stale row is touched, leaving the index exactly as it was. Fresh chunks
  stream through the same spill machinery in bounded waves.
- **Spills are per-build and always released.** Names carry pid + a random
  token (concurrent builds — or a CLI racing the MCP server across PID
  namespaces — own separate files); a sweep reclaims leftovers from crashed
  runs (own dead spills instantly, foreign ones past 24h, with an mtime
  keepalive during long embed phases).
- **Failure still degrades, never breaks.** `completion` never rejects; any
  vector-stage failure (model download, ENOSPC on a spill — WriteStreams carry
  persistent error listeners now, an unhandled 'error' would kill the server)
  lands as `vectors:"none"` + `embedError` with the keyword table live.
- **Bounded arenas.** Embed input is capped at `CX_EMBED_MAX_CHARS` (default
  8000 — far above the default model's 256-token window, so vectors are
  unchanged; tune it if you point `CX_EMBED_MODEL` at a long-context model).

One deliberate deviation from the issue text: it suggested interleaving
chunking with stage-1 appends. That drops the live table at the start of the
walk and breaks swap atomicity for concurrent readers (confirmed by
adversarial review of a first implementation that did exactly that), so this
PR spools first and swaps atomically instead — same peak-memory bound, none of
the semantic regressions.

## Acceptance criteria

Measured on the exact repro shape from #9 (370 files / 4,764 chunks, local
MiniLM q8, \`cx index\` CLI):

| | peak RSS, surviving process | embed child (exits) | wall |
|---|---|---|---|
| main | 2,485 MB | — | 167 s |
| this PR | **521 MB** | 2,081 MB → returned to OS | 166 s |

- Peak memory scales with batch size, not repo size; server memory returns to
  baseline once the child exits and spills are deleted. 
- Retrieval unchanged: same model, same embed texts (cap is inert for the
  default model), identical chunk set. 
- Staged readiness preserved: keyword-first, vectors backfill, same manifest
  states, `completion` never rejects. 

## Testing

- `npm run build` + `npm test`: 100/100 (10 new tests in
  `test/streaming.test.ts`: multi-wave builds past `APPEND_BATCH`, `embed()`
  -only fakes, model-failure degradation, short-embedding-stream refusal,
  multi-wave sync, overlapping concurrent builds, empty corpus with an
  embedder, sync embed-failure leaving the index intact, phase order + embed
  progress).
- Two adversarial review rounds over the diff (21 confirmed findings in round
  1 — all fixed and re-verified in round 2, which added 4 more, also fixed).
