### PR TITLE
Bump infino to 0.5.1, adapt vector index spec, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep dependencies current, most importantly the @infino-ai/infino engine —
+# a new engine release should show up here as a PR that has to pass CI, not
+# as silent drift.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "@infino-ai/infino": "^0.1.4",
+        "@infino-ai/infino": "^0.5.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "commander": "^15.0.0",
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@infino-ai/infino": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@infino-ai/infino/-/infino-0.1.4.tgz",
-      "integrity": "sha512-SZOZEmVQwc4lkJ6BosSWZbpBe11colKStzF3PsRYyL961cgoqqsyqA+lkr2rPhE4D/QxyveYlmKNLTaxxX7Nig==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@infino-ai/infino/-/infino-0.5.1.tgz",
+      "integrity": "sha512-AZSRkQT/GtwwyS6YKa2FQibaZdD2XPiKx0D34W6iuxSVuIJhLuleTzklf/HuE6SN5DaJC6MWmTAw82PbfSXNwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17"
@@ -1006,12 +1006,12 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "infx-darwin-arm64": "0.1.4",
-        "infx-darwin-x64": "0.1.4",
-        "infx-linux-arm64-gnu": "0.1.4",
-        "infx-linux-arm64-musl": "0.1.4",
-        "infx-linux-x64-gnu": "0.1.4",
-        "infx-linux-x64-musl": "0.1.4"
+        "infx-darwin-arm64": "0.5.1",
+        "infx-darwin-x64": "0.5.1",
+        "infx-linux-arm64-gnu": "0.5.1",
+        "infx-linux-arm64-musl": "0.5.1",
+        "infx-linux-x64-gnu": "0.5.1",
+        "infx-linux-x64-musl": "0.5.1"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2682,9 +2682,9 @@
       }
     },
     "node_modules/infx-darwin-arm64": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-darwin-arm64/-/infx-darwin-arm64-0.1.4.tgz",
-      "integrity": "sha512-EGzaSet2ykBasEMaDZ3rm7GBi2uZmwUm906FB0IcdWOoD/A6rRqiRwVTHDLesweTDI0d5OBBexERx3BnueTIPA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-darwin-arm64/-/infx-darwin-arm64-0.5.1.tgz",
+      "integrity": "sha512-L4R9rv2mRStzKqA6lxkEzSfIHlT0TNzdRvbjxkKPlqG/F8e1VdayvYuPPyq2BgZQXlURucVa5y8dN5ZH37dvbQ==",
       "cpu": [
         "arm64"
       ],
@@ -2698,9 +2698,9 @@
       }
     },
     "node_modules/infx-darwin-x64": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-darwin-x64/-/infx-darwin-x64-0.1.4.tgz",
-      "integrity": "sha512-8bWXL8HtxV/FSEOar5vzoedCRT7GjPP4A/KHE4FYpKsNDCyC3P+tJLQVwDGKIKsER8tcKxAKR9S4s94S6wRDoQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-darwin-x64/-/infx-darwin-x64-0.5.1.tgz",
+      "integrity": "sha512-BG+hpNt09miEukKoE1TPQWrUPQQRXMw37CGRUmAksciqEKIbU47R6WxORm42WGleGRulZMqo0ByLe0R7pnYpQw==",
       "cpu": [
         "x64"
       ],
@@ -2714,11 +2714,14 @@
       }
     },
     "node_modules/infx-linux-arm64-gnu": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-linux-arm64-gnu/-/infx-linux-arm64-gnu-0.1.4.tgz",
-      "integrity": "sha512-mQbuQBtEIAchRiPMuZzfH8OZXhWYmvhnOldpSQF/I9bAnRg2AgUUNu2lx/o4g31qEjAEnjk67zxn4YtALpaMJA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-gnu/-/infx-linux-arm64-gnu-0.5.1.tgz",
+      "integrity": "sha512-snPw19oRhoyAnoz7t9juxj3S+tMpQdf7dxwb44ld9hZoez29fTgnpMGGTnXc1gGbvHFiDp9N2YNFdkyCOKJdnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2730,11 +2733,14 @@
       }
     },
     "node_modules/infx-linux-arm64-musl": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-linux-arm64-musl/-/infx-linux-arm64-musl-0.1.4.tgz",
-      "integrity": "sha512-VubHckuy9ZiBwmGe8B01X7gSXBUPNEADEojvGh4piZwCZonpfgYjoxQmdM2sIf4u2c3p2rwtlAG9N2mRnVph8w==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-musl/-/infx-linux-arm64-musl-0.5.1.tgz",
+      "integrity": "sha512-s5H3QwOxxyneOChwFLWv9oSct7HSIGFnD1IqicPX9LWcs4hsMd2SRo+fUrbGKGreLQDOUE8gAt7iBuMpfg0pDQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2746,11 +2752,14 @@
       }
     },
     "node_modules/infx-linux-x64-gnu": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-linux-x64-gnu/-/infx-linux-x64-gnu-0.1.4.tgz",
-      "integrity": "sha512-Ai6zqmM60QdwcS74aShcKFLD9pf209oobWVMrHT/yIqYcgmbB2Cfd3Rb80r137MYm1fMQnLWmoIye0+an+zNJQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-gnu/-/infx-linux-x64-gnu-0.5.1.tgz",
+      "integrity": "sha512-c/vjvQWR0ZuTrmUFBO1uMHLTcAUcc/xdCEwQeiEceSO9YrIErTyHixXlB9zwGTelwHnMsx4z7B16tfO34PANcQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2762,11 +2771,14 @@
       }
     },
     "node_modules/infx-linux-x64-musl": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/infx-linux-x64-musl/-/infx-linux-x64-musl-0.1.4.tgz",
-      "integrity": "sha512-da5dSC1uYN/vBFOi12UecDi6/PqGBWZ/9PIiuqpnPYaOXYsuxg2fT+tCtxEVM31oJi6Hu+4JcYdHaJmnljhzSg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-musl/-/infx-linux-x64-musl-0.5.1.tgz",
+      "integrity": "sha512-9hZO1AvJ7lN9a157DYvwm43EULBlb0RTYg50DQMvaMfj6NjLcEl5jfWNYmICeN5TDXQamcfXuvjCieXVh7lfTA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "@infino-ai/infino": "^0.1.4",
+    "@infino-ai/infino": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "commander": "^15.0.0",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -54,10 +54,6 @@ export const EMBED_BATCH = 32;
  * files) without changing retrieval. */
 export const EMBED_MAX_CHARS = Number(process.env.CX_EMBED_MAX_CHARS ?? 8000);
 
-/** IVF centroid count for the vector index. 1 = exact scan - perfect recall,
- * and at local-repo scale (tens of thousands of chunks) still milliseconds. */
-export const N_CENT = 1;
-
 /** Default number of search hits. Configurable per call (the `k` tool param /
  * CLI `-k`) and via CX_SEARCH_K for config/CI-level defaults. */
 export const DEFAULT_SEARCH_K = Number(process.env.CX_SEARCH_K ?? 10);

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -46,7 +46,7 @@ import { createInterface } from "node:readline";
 import { join, relative, sep } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { IndexSpec, type Connection, type OptimizeOptions, type RowRecord } from "@infino-ai/infino";
-import { APPEND_BATCH, EMBED_BATCH, N_CENT, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
+import { APPEND_BATCH, EMBED_BATCH, TABLE, DEFAULT_CAPS, type IndexCaps } from "./config.js";
 import { walkRepo } from "./walker.js";
 import { shouldIndexFile, chunkFile, looksBinary, embedText, type Chunk } from "./chunker.js";
 import { readManifest, writeManifest, INDEX_FORMAT_VERSION, type Manifest, type VectorState } from "./manifest.js";
@@ -254,7 +254,7 @@ export async function indexRepoStaged(opts: IndexOptions): Promise<StagedIndexRu
         const hybridTable = db.createTable(
           TABLE,
           { ...TEXT_SCHEMA, embedding: { vector: dim } },
-          new IndexSpec().fts("content").vector("embedding", dim, N_CENT, "cosine"),
+          new IndexSpec().fts("content").vector("embedding", dim, "cosine"),
         );
         // Zero chunks ⇒ no vector spill was ever written; the empty table is
         // already complete.


### PR DESCRIPTION
Moves the `@infino-ai/infino` pin from `^0.1.4` to `^0.5.1` (four minors of drift) and refreshes the lockfile.

**One API adaptation.** `IndexSpec.vector()` dropped its centroid-count argument — the engine now derives the IVF centroid count from the data at build time. The `N_CENT` constant existed to force `1` (exact scan, perfect recall at local-repo scale), so it goes away with the argument.

**Recall verified.** Since exact-scan can no longer be forced, I compared `bench/recall.mjs` on this branch against the last main run on 0.1.4, same corpus size (172 vs 171 chunks):

| mode | 0.1.4 (main CI) | 0.5.1 (this branch) |
|---|---|---|
| vector-only | hit@5 11/12, MRR@5 0.625 | hit@5 11/12, MRR@5 0.611 |
| hybrid | hit@5 10/12, MRR@5 0.674 | hit@5 11/12, MRR@5 0.565 |

Hit@5 holds or improves in both modes; hybrid MRR dips with the extra hit landing lower in the top 5. No regression worth blocking on, and the report-only recall job keeps tracking it.

**Tests.** All 103 tests pass on the new engine, including the streaming staged-build and sync integration tests.

**Dependabot.** Daily npm + weekly github-actions version updates, so the next engine release arrives as a PR that must pass this suite instead of accruing as drift. For 0.x versions the caret range is patch-only, so every minor engine bump comes through such a gated PR.