### PR TITLE
release-prep: stamp the plugin version pins in lockstep

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -143,7 +143,27 @@ jobs:
         run: |
           set -euo pipefail
           npm version "$BUMP" --no-git-tag-version
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          # The Claude Code plugin launches the server through an exact npx
+          # version pin, and its manifest version rides in lockstep with the
+          # package (enforced by test/plugin.test.ts) — stamp both, or CI
+          # fails the release PR.
+          version="$(node -p "require('./package.json').version")"
+          node - "$version" <<'NODE'
+          const fs = require("fs");
+          const version = process.argv[2];
+          // Substitute just the version text so the files keep their
+          // hand-written formatting; verify the result still parses.
+          const sub = (path, pattern, replacement) => {
+            const before = fs.readFileSync(path, "utf8");
+            const after = before.replace(pattern, replacement);
+            if (after === before) throw new Error(`${path}: nothing matched ${pattern}`);
+            JSON.parse(after);
+            fs.writeFileSync(path, after);
+          };
+          sub(".claude-plugin/plugin.json", /"version": "[^"]+"/, `"version": "${version}"`);
+          sub(".mcp.json", /@infino-ai\/code-context@[^"]+/, `@infino-ai/code-context@${version}`);
+          NODE
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Push the release branch and open the PR
         if: steps.classify.outputs.bump != 'skip'


### PR DESCRIPTION
The first release PR (#23) failed CI on `test/plugin.test.ts`: the bump step only moved `package.json`, but this repo also carries the release version in two more places — the exact `npx` pin in `.mcp.json` and the plugin manifest version in `.claude-plugin/plugin.json`. The lockstep test caught it exactly as designed.

The bump step now substitutes just the version text in both files (keeping their hand-written formatting — a JSON round-trip would reformat the inline `author`/`args`) and re-parses to prove the result is still valid JSON. Verified locally by executing the step with `BUMP=minor`: all four files stamp to 0.2.0 with one-line diffs and `test/plugin.test.ts` passes against the stamped tree.

After this merges, close #23 (its branch predates the fix) and re-dispatch `Release prep` — the fresh `release: v0.2.0` PR will carry all four version stamps.