### PR TITLE
release-prep: force-push the machine-owned release branch

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -183,7 +183,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git commit -am "release: v$VERSION"
-          git push origin "$branch"
+          # Force: release-* branches are machine-owned, and a stale branch
+          # from a closed release PR would otherwise wedge the push.
+          git push --force origin "$branch"
 
           body="Release PR stamped by the \`Release prep\` workflow: \
           **v$VERSION** (\`$BUMP\` bump, changes since \`$LAST\`).


### PR DESCRIPTION
One-line hardening from a failure hit live: closing release PR #23 left its `release-v0.2.0` branch on the remote, and the re-dispatched prep run — computing the same version — failed its push with non-fast-forward, needing a manual branch delete to unblock.

`release-vX.Y.Z` branches are created exclusively by this workflow, so force-pushing them can never destroy human work; the stale ref is always a dead artifact of a superseded release attempt.