### PR TITLE
Stop routine updates from starving the engine bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 # Keep dependencies current, most importantly the @infino-ai/infino engine —
 # a new engine release should show up here as a PR that has to pass CI, not
 # as silent drift.
+#
+# Dependabot has no priority setting, and a full queue means it simply opens no
+# more PRs — so the dependency that matters most here can be the one left out
+# (it has happened: a full queue of routine updates starved an engine release).
+# The fix is to keep the queue from filling: every dependency except the engine
+# rides in one grouped PR, occupying a single slot however many are pending,
+# while @infino-ai/infino matches no group and so always gets its own.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -8,8 +15,25 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@infino-ai/infino"
+    ignore:
+      # zod 4 moved `z.record` to a two-argument form, so the MCP tool input
+      # schemas need migrating before it can land. Left unignored it sits red
+      # inside the grouped PR and blocks every routine update with it. Drop
+      # this entry with the migration.
+      - dependency-name: zod
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,13 +21,6 @@ updates:
           - "*"
         exclude-patterns:
           - "@infino-ai/infino"
-    ignore:
-      # zod 4 moved `z.record` to a two-argument form, so the MCP tool input
-      # schemas need migrating before it can land. Left unignored it sits red
-      # inside the grouped PR and blocks every routine update with it. Drop
-      # this entry with the migration.
-      - dependency-name: zod
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Move the declared range, not just the lockfile. The default only edits
+    # package.json when the new version falls outside the range, so an engine
+    # patch inside `^0.5.x` updated the lockfile alone: CI then tested the new
+    # version while the published package still accepted any 0.5.x, including
+    # patches nothing verifies any more. `increase` raises the floor to the
+    # version actually tested.
+    versioning-strategy: increase
     open-pull-requests-limit: 5
     groups:
       dependencies:

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -301,7 +301,7 @@ export async function serveMcp(rootPath?: string): Promise<void> {
           .string()
           .describe("A single read-only SELECT or WITH statement. May use search table functions and {{name}} vector placeholders."),
         embed: z
-          .record(z.string())
+          .record(z.string(), z.string())
           .optional()
           .describe('Map of placeholder name → query text, embedded server-side. E.g. {"q":"vector indexing"} fills {{q}}.'),
         path: z


### PR DESCRIPTION
**Dependabot has no priority setting**, and a full queue means it simply opens no more PRs, so the dependency that matters most can be the one left out. That is not hypothetical here: this repo pins `^0.5.1` while the engine is at **0.5.2**, and no bump PR exists, because the npm queue is full at 5 (one of them permanently red).

Two entries for the same ecosystem and directory are not allowed, so the engine cannot have its own limit. What works instead: **every dependency except the engine rides in one grouped PR**, occupying a single slot however many are pending, while the engine matches no group and therefore always gets its own PR (GitHub: "any outdated dependencies that do not match a rule are updated in individual pull requests"). The queue can no longer fill, so the engine can no longer be squeezed out.

Also ignoring `zod` 4 until the `z.record(key, value)` migration lands (PR #19 is red on exactly that), so a known-incompatible major cannot sit inside the grouped PR and block every routine update with it. Drop the ignore with the migration.