### PR TITLE
release-prep: don't cut a release for a lockfile-only change

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -14,7 +14,10 @@ name: Release prep
 # warrant one:
 #
 #   minor — behavior of the shipped artifact changes:
-#             src/**, package.json, package-lock.json
+#             src/**, package.json (package-lock.json is skip: npm never
+#             publishes it, and an installer resolves package.json's ranges
+#             itself, so an in-range dependency bump changes what CI builds
+#             from and nothing a consumer receives)
 #   patch — only artifact/catalog text or metadata changes:
 #             README.md, LICENSE, server.json
 #   skip  — nothing a release consumer receives changes (no PR at all):
@@ -110,7 +113,7 @@ jobs:
           minor_files=""; patch_files=""; skip_files=""
           while IFS= read -r f; do
             case "$f" in
-              src/*|package.json|package-lock.json)
+              src/*|package.json)
                 bump=minor
                 minor_files="$minor_files$f, " ;;
               README.md|LICENSE|server.json)


### PR DESCRIPTION
Same fix as infino-ai/infino-mcp#21, found while reviewing an engine-bump PR there that touched **only** `package-lock.json` — correct dependabot behavior, since `^0.5.1` already permits 0.5.2 (a caret on a 0.x version means `>=0.5.1 <0.6.0`), so the manifest range needs no edit.

The classifier had `package-lock.json` in the minor bucket, so an in-range dependency bump would cut a release no consumer can observe: npm never publishes a lockfile, the tarball here is `dist/` plus README/LICENSE/package.json, and an installer resolves the ranges in `package.json` for itself.

`package-lock.json` moves to the skip bucket. `package.json` stays in minor: a **range** change is precisely what reaches consumers, and dependabot does edit the manifest when a version lands outside the current range.

(Contrast infino-cli, where `Cargo.lock` correctly stays in minor: cargo-dist compiles the shipped binaries from that lockfile, so there a lock change really does change the artifact.)