### PR TITLE
chunker: the last chunk ends at the file's last line, not one past it

### DIFF
--- a/src/core/chunker.ts
+++ b/src/core/chunker.ts
@@ -419,6 +419,13 @@ export async function chunkFile(path: string, content: string): Promise<Chunk[]>
   if (!content.trim()) return [];
   const lang = langFor(path);
   const lines = content.split("\n");
+  // A trailing newline terminates the last line rather than starting a new
+  // one, but split() leaves an empty element behind it. Both span builders end
+  // the final span at lines.length, so keeping that element would put the last
+  // chunk's endLine (and the indexed end_line) one past the file's last line.
+  // Drop exactly one: further blank lines before it are real lines. A CRLF
+  // file leaves the same empty element, so this covers it too.
+  if (lines[lines.length - 1] === "") lines.pop();
 
   let defs: DefSite[] | undefined;
   let spans: Array<[number, number]>;

--- a/test/chunker.test.ts
+++ b/test/chunker.test.ts
@@ -95,6 +95,32 @@ describe("chunkFile", () => {
     expect(chunks[1].startLine).toBe(51);
   });
 
+  it("ends the last chunk at the file's last line, not one past it", async () => {
+    // Nearly every file ends with "\n". The empty string split() leaves behind
+    // that final newline is not a line, so MAX(end_line) must equal `wc -l`
+    // through every span builder: fixed windows, tree-sitter, markdown.
+    const fn = (i: number) => `export function f${i}() {\n${"  // body\n".repeat(15)}  return ${i};\n}\n`;
+    const cases: Array<{ path: string; content: string; lines: number }> = [
+      { path: "notes.txt", content: "a\nb\nc\n", lines: 3 },
+      { path: "notes.txt", content: "a\r\nb\r\nc\r\n", lines: 3 },
+      { path: "notes.txt", content: "a\nb\nc", lines: 3 }, // no trailing newline: nothing to drop
+      { path: "notes.txt", content: "a\n\n\n", lines: 3 }, // blank last lines are still lines
+      { path: "notes.txt", content: Array.from({ length: 150 }, (_, i) => `line ${i}`).join("\n") + "\n", lines: 150 },
+      { path: "mod.ts", content: "export function a() {\n  return 1;\n}\n\nexport function b() {\n  return 2;\n}\n", lines: 7 },
+      { path: "mod.ts", content: Array.from({ length: 6 }, (_, i) => fn(i)).join(""), lines: 6 * 18 },
+      { path: "doc.md", content: "# Title\ntext\n## Second\nmore\n", lines: 4 },
+    ];
+    for (const { path, content, lines } of cases) {
+      const chunks = await chunkFile(path, content);
+      expect(chunks[0].startLine).toBe(1);
+      // No gaps between consecutive chunks (fixed windows overlap, so <=).
+      for (let i = 1; i < chunks.length; i++) {
+        expect(chunks[i].startLine).toBeLessThanOrEqual(chunks[i - 1].endLine + 1);
+      }
+      expect(Math.max(...chunks.map((c) => c.endLine))).toBe(lines);
+    }
+  });
+
   it("carries the path and language on every chunk", async () => {
     const chunks = await chunkFile("src/x.py", "def f():\n    return 1\n");
     expect(chunks[0]).toMatchObject({ path: "src/x.py", lang: "py", startLine: 1 });


### PR DESCRIPTION
chunkFile splits content on "\n". A file that ends with a newline, which is nearly every file, leaves a trailing empty string, so lines.length was the real line count plus one. Both span builders (fixedWindows and packSegments) end their last span at lines.length, so the last chunk's endLine, and the end_line stored in the index, ran one line past the file. On the bench repo MAX(end_line) was `wc -l` plus one for every file (Cargo.toml 443 vs 442, src/lib.rs 220 vs 219, README.md 554 vs 553). A hit's path:start-end citation for the last chunk pointed past the file, and any answer that read a file's length off MAX(end_line) was off by one.

Drop exactly one trailing empty element before computing spans. Blank lines ahead of the final newline are still lines; a CRLF file leaves the same empty element, so it is covered without changing the split. How tree-sitter definition rows map to lines (d.row + 1) and the empty-span guard are unchanged, and spans still tile the file.

The regression test covers fixed windows, tree-sitter, and markdown, with and without the trailing newline; it fails before this change.

Existing indexes keep the old end_line values until they are reindexed.