### PR TITLE
Align the registry description with the npm one

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.infino-ai/code-context",
-  "description": "Local code search for AI coding agents: hybrid search and SQL aggregation over an in-repo index.",
+  "description": "Local code search for AI coding agents: hybrid keyword + semantic search and SQL relevance-ranked aggregation over an index that lives in plain files. No accounts, no keys, no server.",
   "repository": {
     "url": "https://github.com/infino-ai/code-context",
     "source": "github"


### PR DESCRIPTION
One line. The MCP registry description lagged the npm one and said less about what makes the tool worth picking.

Before: "Local code search for AI coding agents: hybrid search and SQL aggregation over an in-repo index."
After: "Local code search for AI coding agents: hybrid keyword + semantic search and SQL relevance-ranked aggregation over an index that lives in plain files. No accounts, no keys, no server."

README, keywords, plugin manifests, and tool descriptions are already in this shape and stay untouched. The registry and the aggregators re-pull the description on the next npm publish.