### PR TITLE
server.json: fit the description inside the registry's 100-char cap

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.infino-ai/code-context",
-  "description": "Local code search for AI coding agents: hybrid keyword + semantic search and SQL relevance-ranked aggregation over an index that lives in plain files. No accounts, no keys, no server.",
+  "description": "Local code search for AI coding agents: hybrid keyword + semantic search and SQL over plain files.",
   "repository": {
     "url": "https://github.com/infino-ai/code-context",
     "source": "github"


### PR DESCRIPTION
The v0.5.0 release published to npm but the MCP Registry stage failed with a 422: the registry caps `description` at 100 characters and the copy in server.json ran 183.

This trims it to 98 characters keeping the differentiators (hybrid keyword + semantic search, SQL, plain files). The full copy stays on npm through package.json, which has no cap.

After merge, a manual dispatch of the Publish workflow with dry_run=false finishes the v0.5.0 registry publish: the npm stage detects 0.5.0 is already up and skips, the registry stage publishes the corrected entry.